### PR TITLE
feat: improve CLI logging and batch exits

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,13 @@
 # Release Notes
 
-## Unreleased
+## v3.3.0
+**Release Date**: 2026-05-10
+
+### Features
+- Added global `--verbose` and `--log-file` CLI options.
+- Added structured batch summaries for recursive metadata removal.
+- Added script-friendly exit codes for success, usage/no-op, full failure, and
+  partial failure cases.
 
 ### Maintenance
 - Added Docker build verification to CI and fixed the Docker build context so
@@ -9,6 +16,7 @@
   coverage.
 - Replaced stale planning and self-improvement docs with current roadmap and
   maintenance guidance.
+- Updated the release action and Docker base image through Dependabot.
 
 ## v3.2.0
 **Release Date**: 2026-05-09

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -43,3 +43,12 @@ updated_file = MetadataProcessor().edit_metadata(
 )
 print(updated_file)
 ```
+
+## CLI Exit Codes
+
+The CLI returns stable exit codes for automation:
+
+- `0`: success.
+- `1`: processing failure.
+- `2`: invalid input, usage error, or no supported files.
+- `3`: partial batch failure.

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -14,11 +14,8 @@ privacy risk before implementation.
 - Add Docker build verification in CI.
 
 ### CLI Usability
-- Add a `--verbose` flag that maps to `METADATA_CLEANER_LOG_LEVEL=DEBUG`.
-- Add a `--log-file` option for explicit file logging.
-- Add a structured batch summary showing successes, skipped files, and failures.
-- Improve exit codes so scripts can distinguish no-op, partial failure, and full
-  failure cases.
+- Add richer batch reports that can be exported as JSON.
+- Add a `--quiet` flag for automation that only needs machine-readable output.
 
 ### File Format Support
 - Evaluate HEIC/HEIF support with a clear dependency strategy.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -13,6 +13,20 @@ poetry install --with dev
 poetry run metadata-cleaner --help
 ```
 
+## Global Options
+
+Enable debug logs for any command:
+
+```bash
+metadata-cleaner --verbose view my_photo.jpg
+```
+
+Write logs to a rotating file:
+
+```bash
+metadata-cleaner --log-file ./metadata-cleaner.log delete sample.jpg
+```
+
 ## Commands
 
 View metadata:
@@ -39,6 +53,12 @@ Process a directory recursively:
 metadata-cleaner delete ./images --output ./cleaned-images
 ```
 
+Batch runs end with a structured summary:
+
+```text
+Summary: succeeded=12, failed=1, skipped=0, total=13
+```
+
 Preview work without creating files:
 
 ```bash
@@ -50,6 +70,13 @@ Edit metadata for formats with editing support:
 ```bash
 metadata-cleaner edit song.mp3 --changes '{"artist": "Unknown"}'
 ```
+
+## Exit Codes
+
+- `0`: command completed successfully.
+- `1`: command ran but all processing failed.
+- `2`: invalid input, usage issue, or no supported files were found.
+- `3`: batch processing completed with partial failures.
 
 ## Supported Formats
 
@@ -69,11 +96,14 @@ Some formats require system tools:
 Logs are written to stderr by default. To opt into file logging:
 
 ```bash
-METADATA_CLEANER_LOG_FILE=./metadata-cleaner.log metadata-cleaner delete sample.jpg
+metadata-cleaner --log-file ./metadata-cleaner.log delete sample.jpg
 ```
 
 To increase verbosity:
 
 ```bash
-METADATA_CLEANER_LOG_LEVEL=DEBUG metadata-cleaner view sample.jpg
+metadata-cleaner --verbose view sample.jpg
 ```
+
+The environment variables `METADATA_CLEANER_LOG_FILE` and
+`METADATA_CLEANER_LOG_LEVEL` are also supported for automation.

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -1,5 +1,6 @@
 import json
 import os
+from dataclasses import dataclass, field
 from typing import Optional
 
 import click
@@ -7,8 +8,54 @@ from tqdm import tqdm
 
 from m_c.cli.utils import format_metadata_output
 from m_c.core.file_utils import get_safe_output_path, get_supported_files
-from m_c.core.logger import logger
+from m_c.core.logger import configure_logging, logger
 from m_c.core.metadata_processor import MetadataProcessor
+
+EXIT_SUCCESS = 0
+EXIT_FAILURE = 1
+EXIT_USAGE = 2
+EXIT_PARTIAL_FAILURE = 3
+
+
+@dataclass
+class BatchSummary:
+    total: int
+    succeeded: int = 0
+    failed: int = 0
+    skipped: int = 0
+    failures: list[str] = field(default_factory=list)
+
+
+def _echo_batch_summary(summary: BatchSummary, dry_run: bool) -> None:
+    if dry_run:
+        click.echo(
+            "Dry run summary: "
+            f"would_process={summary.succeeded}, "
+            f"failed={summary.failed}, skipped={summary.skipped}, "
+            f"total={summary.total}"
+        )
+    else:
+        click.echo(
+            "Summary: "
+            f"succeeded={summary.succeeded}, failed={summary.failed}, "
+            f"skipped={summary.skipped}, total={summary.total}"
+        )
+
+    for failure in summary.failures[:10]:
+        click.echo(f"Failed: {failure}")
+
+    if len(summary.failures) > 10:
+        click.echo(f"Additional failures: {len(summary.failures) - 10}")
+
+
+def _exit_for_summary(ctx: click.Context, summary: BatchSummary, dry_run: bool) -> None:
+    if dry_run:
+        ctx.exit(EXIT_SUCCESS if summary.failed == 0 else EXIT_PARTIAL_FAILURE)
+    if summary.succeeded == summary.total:
+        ctx.exit(EXIT_SUCCESS)
+    if summary.succeeded == 0:
+        ctx.exit(EXIT_FAILURE)
+    ctx.exit(EXIT_PARTIAL_FAILURE)
 
 
 def _parse_json_option(json_string: str) -> Optional[dict]:
@@ -39,17 +86,26 @@ def _batch_output_path(
 
 
 @click.group()
-def cli():
+@click.option("--verbose", is_flag=True, help="Enable debug logging.")
+@click.option(
+    "--log-file",
+    type=click.Path(dir_okay=False, path_type=str),
+    default=None,
+    help="Write logs to a rotating file.",
+)
+def cli(verbose, log_file):
     """Metadata Cleaner - view, remove, and edit metadata."""
+    configure_logging(verbose=verbose, log_file=log_file)
 
 
 @cli.command()
 @click.argument("file")
-def view(file):
+@click.pass_context
+def view(ctx, file):
     """View metadata of a file."""
     if not os.path.isfile(file):
         click.echo("Error: file does not exist or is not a regular file.")
-        return
+        ctx.exit(EXIT_USAGE)
 
     metadata = MetadataProcessor().view_metadata(file)
     click.echo(format_metadata_output(metadata))
@@ -59,25 +115,28 @@ def view(file):
 @click.argument("path")
 @click.option("--output", default=None, help="Output file path or batch directory.")
 @click.option("--dry-run", is_flag=True, help="Show what would be processed.")
-def delete(path, output, dry_run):
+@click.pass_context
+def delete(ctx, path, output, dry_run):
     """Remove metadata from a file or supported files in a directory."""
     files_to_process = get_supported_files(path)
     if not files_to_process:
         click.echo("No supported files found.")
-        return
+        ctx.exit(EXIT_USAGE)
 
     processor = MetadataProcessor()
     if len(files_to_process) == 1 and not os.path.isdir(path):
         result = processor.delete_metadata(files_to_process[0], output, dry_run=dry_run)
         if dry_run:
             click.echo("Dry run complete. No files changed.")
+            ctx.exit(EXIT_SUCCESS)
         elif result:
             click.echo(f"Metadata removed: {result}")
+            ctx.exit(EXIT_SUCCESS)
         else:
             click.echo("Metadata removal failed. Check logs for details.")
-        return
+            ctx.exit(EXIT_FAILURE)
 
-    success_count = 0
+    summary = BatchSummary(total=len(files_to_process))
     click.echo(f"Processing {len(files_to_process)} files...")
     with tqdm(total=len(files_to_process)) as pbar:
         for file_path in files_to_process:
@@ -94,38 +153,42 @@ def delete(path, output, dry_run):
                     dry_run=dry_run,
                 )
                 if result or dry_run:
-                    success_count += 1
+                    summary.succeeded += 1
+                else:
+                    summary.failed += 1
+                    summary.failures.append(file_path)
             except Exception as e:
+                summary.failed += 1
+                summary.failures.append(file_path)
                 logger.error(f"Failed to process {file_path}: {e}", exc_info=True)
             pbar.update(1)
 
-    if dry_run:
-        click.echo(f"Dry run complete. {success_count} files would be processed.")
-    else:
-        click.echo(
-            f"Completed. Successfully processed {success_count}/{len(files_to_process)} files."
-        )
+    _echo_batch_summary(summary, dry_run)
+    _exit_for_summary(ctx, summary, dry_run)
 
 
 @cli.command()
 @click.argument("file")
 @click.option("--changes", required=True, help="JSON object of metadata changes.")
-def edit(file, changes):
+@click.pass_context
+def edit(ctx, file, changes):
     """Edit metadata for supported formats with editing support."""
     if not os.path.isfile(file):
         click.echo("Error: file does not exist or is not a regular file.")
-        return
+        ctx.exit(EXIT_USAGE)
 
     changes_dict = _parse_json_option(changes)
     if changes_dict is None:
         click.echo("Invalid JSON format. Please check and try again.")
-        return
+        ctx.exit(EXIT_USAGE)
 
     result = MetadataProcessor().edit_metadata(file, changes_dict)
     if result:
         click.echo(f"Metadata updated: {result}")
+        ctx.exit(EXIT_SUCCESS)
     else:
         click.echo("Metadata editing failed or is unsupported for this file.")
+        ctx.exit(EXIT_FAILURE)
 
 
 if __name__ == "__main__":

--- a/m_c/core/logger.py
+++ b/m_c/core/logger.py
@@ -18,18 +18,31 @@ logger.propagate = False
 
 formatter = logging.Formatter(LOG_FORMAT, DATE_FORMAT)
 
+
+def add_log_file(log_file: str) -> None:
+    """Add a rotating file handler if one is not already configured."""
+    log_file = os.path.abspath(log_file)
+    for handler in logger.handlers:
+        if isinstance(handler, RotatingFileHandler):
+            if os.path.abspath(handler.baseFilename) == log_file:
+                return
+
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    file_handler = RotatingFileHandler(
+        log_file, maxBytes=LOG_ROTATION_SIZE, backupCount=LOG_BACKUP_COUNT
+    )
+    file_handler.setFormatter(formatter)
+    file_handler.setLevel(logger.level)
+    logger.addHandler(file_handler)
+
+
 if not logger.handlers:
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)
 
     if LOG_FILE:
-        os.makedirs(os.path.dirname(os.path.abspath(LOG_FILE)), exist_ok=True)
-        file_handler = RotatingFileHandler(
-            LOG_FILE, maxBytes=LOG_ROTATION_SIZE, backupCount=LOG_BACKUP_COUNT
-        )
-        file_handler.setFormatter(formatter)
-        logger.addHandler(file_handler)
+        add_log_file(LOG_FILE)
 
 
 def set_log_level(level: str) -> None:
@@ -41,3 +54,11 @@ def set_log_level(level: str) -> None:
             handler.setLevel(getattr(logging, level))
     else:
         logger.warning(f"Invalid log level: {level}. Using default: {LOG_LEVEL}")
+
+
+def configure_logging(verbose: bool = False, log_file: str | None = None) -> None:
+    """Apply CLI logging options at runtime."""
+    if verbose:
+        set_log_level("DEBUG")
+    if log_file:
+        add_log_file(log_file)

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -3,6 +3,7 @@ import shutil
 import subprocess
 import unittest
 import wave
+from logging.handlers import RotatingFileHandler
 from click.testing import CliRunner
 import docx
 from PIL import Image
@@ -11,6 +12,7 @@ import pypdf
 from m_c.cli.main import cli
 from m_c.core.metadata_processor import MetadataProcessor
 from m_c.core.file_utils import validate_file, get_safe_output_path
+from m_c.core.logger import logger
 from m_c.handlers.base_handler import BaseHandler
 from m_c.handlers.video_handler import VideoHandler
 
@@ -245,10 +247,65 @@ class TestMetadataCleaner(unittest.TestCase):
 
             self.assertEqual(result.exit_code, 0, result.output)
             self.assertIn(
-                "Dry run complete. 1 files would be processed.",
+                "Dry run summary: would_process=1, failed=0, skipped=0, total=1",
                 result.output,
             )
             self.assertFalse(os.path.exists("outputs"))
+
+    def test_cli_batch_partial_failure_exit_code(self):
+        """Batch delete should report partial failure distinctly."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            os.makedirs("inputs", exist_ok=True)
+            Image.new("RGB", (10, 10), color="purple").save(
+                os.path.join("inputs", "photo.jpg"),
+                "jpeg",
+            )
+            with open(os.path.join("inputs", "broken.pdf"), "wb") as broken_pdf:
+                broken_pdf.write(b"not a valid pdf")
+
+            result = runner.invoke(cli, ["delete", "inputs", "--output", "outputs"])
+
+            self.assertEqual(result.exit_code, 3, result.output)
+            self.assertIn("Summary: succeeded=1, failed=1, skipped=0, total=2", result.output)
+            self.assertIn("Failed:", result.output)
+
+    def test_cli_no_supported_files_exit_code(self):
+        """CLI should distinguish no-op input from successful work."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            os.makedirs("inputs", exist_ok=True)
+            with open(os.path.join("inputs", "notes.unknown"), "w") as notes:
+                notes.write("nothing to clean")
+
+            result = runner.invoke(cli, ["delete", "inputs"])
+
+            self.assertEqual(result.exit_code, 2, result.output)
+            self.assertIn("No supported files found.", result.output)
+
+    def test_cli_verbose_log_file_option(self):
+        """Global CLI options should enable explicit file logging."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Image.new("RGB", (10, 10), color="orange").save("photo.jpg", "jpeg")
+            log_path = os.path.abspath("metadata-cleaner.log")
+
+            result = runner.invoke(
+                cli,
+                ["--verbose", "--log-file", log_path, "delete", "photo.jpg", "--dry-run"],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertTrue(os.path.exists(log_path))
+            with open(log_path) as log_file:
+                log_content = log_file.read()
+            self.assertIn("[DRY-RUN]", log_content)
+
+            for handler in list(logger.handlers):
+                if isinstance(handler, RotatingFileHandler):
+                    if os.path.abspath(handler.baseFilename) == log_path:
+                        logger.removeHandler(handler)
+                        handler.close()
 
     def test_cli_rejects_invalid_edit_json(self):
         """CLI edit command should fail gracefully for invalid JSON."""
@@ -258,7 +315,7 @@ class TestMetadataCleaner(unittest.TestCase):
             ["edit", self.test_files["document"], "--changes", "{invalid"],
         )
 
-        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(result.exit_code, 2, result.output)
         self.assertIn("Invalid JSON format", result.output)
 
     def test_generated_wav_metadata_removal_preserves_original(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.2.0"
+version = "3.3.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add global --verbose and --log-file CLI options
- add structured batch summaries for delete runs
- add explicit exit codes for success, usage/no-op, failure, and partial failure
- document the v3.3.0 behavior and update the roadmap

## Verification
- poetry check --lock
- pytest: 19 passed, 1 skipped
- flake8 m_c manage.py
- pip-audit: no known vulnerabilities found
- poetry build: metadata-cleaner 3.3.0