### PR TITLE
ci: smoke test installed package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,38 @@ jobs:
 
       - name: Build Docker image
         run: docker build --tag metadata-cleaner:test .
+
+  package-smoke:
+    name: Package smoke
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        run: pipx install poetry==2.2.1
+
+      - name: Build package
+        run: poetry build
+
+      - name: Install wheel in clean environment
+        run: |
+          python -m venv /tmp/metadata-cleaner-smoke
+          /tmp/metadata-cleaner-smoke/bin/python -m pip install --upgrade pip
+          /tmp/metadata-cleaner-smoke/bin/python -m pip install dist/*.whl
+
+      - name: Smoke test installed CLI
+        run: |
+          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner --help
+          /tmp/metadata-cleaner-smoke/bin/python - <<'PY'
+          from PIL import Image
+          Image.new("RGB", (8, 8), color="white").save("smoke.jpg", "jpeg")
+          PY
+          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner view smoke.jpg
+          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner delete smoke.jpg --dry-run

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## v3.3.1
+**Release Date**: 2026-05-10
+
+### Maintenance
+- Added a package smoke-test CI job that builds the wheel, installs it into a
+  clean virtual environment, and runs the installed `metadata-cleaner` CLI.
+
 ## v3.3.0
 **Release Date**: 2026-05-10
 

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -15,7 +15,8 @@ poetry run pip-audit
 poetry build
 ```
 
-The CI workflow mirrors these checks and also builds the Docker image.
+The CI workflow mirrors these checks, builds the Docker image, and smoke-tests
+the built wheel in a clean virtual environment.
 
 ## Dependency Updates
 
@@ -42,6 +43,7 @@ merged. Recommended required checks:
 - `Python 3.12`
 - `Python 3.13`
 - `Docker build`
+- `Package smoke`
 - `Analyze Python`
 
 Allowing administrators to bypass protection is acceptable for a small personal

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -10,8 +10,7 @@ privacy risk before implementation.
 ### Stronger Fixture Coverage
 - Add generated audio fixtures with real metadata tags where practical.
 - Add video integration tests that run when FFmpeg and FFprobe are installed.
-- Add package smoke tests that install the built wheel and run the CLI.
-- Add Docker build verification in CI.
+- Add more package smoke coverage for representative file types.
 
 ### CLI Usability
 - Add richer batch reports that can be exported as JSON.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.3.0"
+version = "3.3.1"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add a Package smoke CI job that builds the wheel
- install the wheel into a clean virtual environment
- run the installed metadata-cleaner CLI against a generated JPEG fixture
- prepare v3.3.1 release notes and version

## Verification
- poetry check --lock
- pytest: 19 passed, 1 skipped
- flake8 m_c manage.py
- pip-audit: no known vulnerabilities found
- poetry build: metadata-cleaner 3.3.1
- local clean-venv smoke skipped because python3.13-venv/ensurepip is unavailable on this machine; the new GitHub CI job verifies it with setup-python