### PR TITLE
feat: add JSON summaries and curated release notes

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -48,6 +48,27 @@ jobs:
         run: |
           poetry build
 
+      - name: Extract Release Notes
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          tag = os.environ["GITHUB_REF_NAME"]
+          text = Path("RELEASE_NOTES.md").read_text(encoding="utf-8")
+          pattern = rf"^## {re.escape(tag)}\n(?P<body>.*?)(?=^## v|\Z)"
+          match = re.search(pattern, text, flags=re.MULTILINE | re.DOTALL)
+          if not match:
+              raise SystemExit(f"No RELEASE_NOTES.md section found for {tag}")
+
+          body = match.group("body").strip()
+          if not body:
+              raise SystemExit(f"Release notes section for {tag} is empty")
+
+          Path("release-notes.md").write_text(body + "\n", encoding="utf-8")
+          PY
+
       - name: Publish Package to PyPI
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
@@ -57,6 +78,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          generate_release_notes: true
+          body_path: release-notes.md
+          generate_release_notes: false
           draft: false
           prerelease: false

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## v3.4.0
+**Release Date**: 2026-05-10
+
+### Features
+- Added `metadata-cleaner delete --json-summary` for machine-readable batch
+  and single-file summaries.
+- Added `metadata-cleaner delete --quiet` to suppress progress and human output
+  for automation.
+
+### Maintenance
+- Updated the release workflow to attach the matching curated section from
+  `RELEASE_NOTES.md` to GitHub Releases.
+
 ## v3.3.1
 **Release Date**: 2026-05-10
 

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -52,7 +52,8 @@ project, but force pushes and branch deletion should stay disabled.
 ## Release Process
 
 1. Update `pyproject.toml`.
-2. Move release notes from unreleased status to the target version.
+2. Add a matching `RELEASE_NOTES.md` section for the target tag, such as
+   `## vX.Y.Z`.
 3. Run the full local verification suite.
 4. Push the release-prep commit and wait for GitHub checks.
 5. Create and push an annotated tag:
@@ -62,4 +63,5 @@ git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-The release workflow publishes to PyPI and creates the GitHub release.
+The release workflow publishes to PyPI and creates the GitHub release using the
+matching `RELEASE_NOTES.md` section as the release body.

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -13,8 +13,8 @@ privacy risk before implementation.
 - Add more package smoke coverage for representative file types.
 
 ### CLI Usability
-- Add richer batch reports that can be exported as JSON.
-- Add a `--quiet` flag for automation that only needs machine-readable output.
+- Add richer batch reports that can be exported to files.
+- Add more machine-readable command output for metadata inspection.
 
 ### File Format Support
 - Evaluate HEIC/HEIF support with a clear dependency strategy.

--- a/docs/PUBLISH.md
+++ b/docs/PUBLISH.md
@@ -38,6 +38,7 @@ git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-Before tagging, update `pyproject.toml` and `RELEASE_NOTES.md`, run the full
-verification suite, and make sure `PYPI_API_TOKEN` is configured in the
-repository secrets.
+Before tagging, update `pyproject.toml`, add a matching `RELEASE_NOTES.md`
+section such as `## vX.Y.Z`, run the full verification suite, and make sure
+`PYPI_API_TOKEN` is configured in the repository secrets. The release workflow
+uses that release-notes section as the GitHub Release body.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -59,6 +59,18 @@ Batch runs end with a structured summary:
 Summary: succeeded=12, failed=1, skipped=0, total=13
 ```
 
+Print a machine-readable summary:
+
+```bash
+metadata-cleaner delete ./images --json-summary
+```
+
+Suppress human progress/output for automation:
+
+```bash
+metadata-cleaner delete ./images --json-summary --quiet
+```
+
 Preview work without creating files:
 
 ```bash

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -26,7 +26,44 @@ class BatchSummary:
     failures: list[str] = field(default_factory=list)
 
 
-def _echo_batch_summary(summary: BatchSummary, dry_run: bool) -> None:
+def _summary_status(summary: BatchSummary, dry_run: bool) -> str:
+    if summary.total == 0:
+        return "no_supported_files"
+    if dry_run:
+        return "success" if summary.failed == 0 else "partial_failure"
+    if summary.succeeded == summary.total:
+        return "success"
+    if summary.succeeded == 0:
+        return "failure"
+    return "partial_failure"
+
+
+def _summary_payload(summary: BatchSummary, dry_run: bool) -> dict:
+    return {
+        "status": _summary_status(summary, dry_run),
+        "dry_run": dry_run,
+        "total": summary.total,
+        "succeeded": summary.succeeded,
+        "failed": summary.failed,
+        "skipped": summary.skipped,
+        "would_process": summary.succeeded if dry_run else None,
+        "failures": summary.failures,
+    }
+
+
+def _echo_batch_summary(
+    summary: BatchSummary,
+    dry_run: bool,
+    json_summary: bool = False,
+    quiet: bool = False,
+) -> None:
+    if json_summary:
+        click.echo(json.dumps(_summary_payload(summary, dry_run), sort_keys=True))
+        return
+
+    if quiet:
+        return
+
     if dry_run:
         click.echo(
             "Dry run summary: "
@@ -115,30 +152,50 @@ def view(ctx, file):
 @click.argument("path")
 @click.option("--output", default=None, help="Output file path or batch directory.")
 @click.option("--dry-run", is_flag=True, help="Show what would be processed.")
+@click.option("--json-summary", is_flag=True, help="Print final summary as JSON.")
+@click.option("--quiet", is_flag=True, help="Suppress progress and human output.")
 @click.pass_context
-def delete(ctx, path, output, dry_run):
+def delete(ctx, path, output, dry_run, json_summary, quiet):
     """Remove metadata from a file or supported files in a directory."""
     files_to_process = get_supported_files(path)
     if not files_to_process:
-        click.echo("No supported files found.")
+        if json_summary:
+            _echo_batch_summary(BatchSummary(total=0), dry_run, json_summary=True)
+        elif not quiet:
+            click.echo("No supported files found.")
         ctx.exit(EXIT_USAGE)
 
     processor = MetadataProcessor()
     if len(files_to_process) == 1 and not os.path.isdir(path):
         result = processor.delete_metadata(files_to_process[0], output, dry_run=dry_run)
+        summary = BatchSummary(total=1)
         if dry_run:
-            click.echo("Dry run complete. No files changed.")
+            summary.succeeded = 1
+            if json_summary:
+                _echo_batch_summary(summary, dry_run, json_summary=True)
+            elif not quiet:
+                click.echo("Dry run complete. No files changed.")
             ctx.exit(EXIT_SUCCESS)
         elif result:
-            click.echo(f"Metadata removed: {result}")
+            summary.succeeded = 1
+            if json_summary:
+                _echo_batch_summary(summary, dry_run, json_summary=True)
+            elif not quiet:
+                click.echo(f"Metadata removed: {result}")
             ctx.exit(EXIT_SUCCESS)
         else:
-            click.echo("Metadata removal failed. Check logs for details.")
+            summary.failed = 1
+            summary.failures.append(files_to_process[0])
+            if json_summary:
+                _echo_batch_summary(summary, dry_run, json_summary=True)
+            elif not quiet:
+                click.echo("Metadata removal failed. Check logs for details.")
             ctx.exit(EXIT_FAILURE)
 
     summary = BatchSummary(total=len(files_to_process))
-    click.echo(f"Processing {len(files_to_process)} files...")
-    with tqdm(total=len(files_to_process)) as pbar:
+    if not quiet and not json_summary:
+        click.echo(f"Processing {len(files_to_process)} files...")
+    with tqdm(total=len(files_to_process), disable=quiet or json_summary) as pbar:
         for file_path in files_to_process:
             try:
                 output_path = _batch_output_path(
@@ -163,7 +220,12 @@ def delete(ctx, path, output, dry_run):
                 logger.error(f"Failed to process {file_path}: {e}", exc_info=True)
             pbar.update(1)
 
-    _echo_batch_summary(summary, dry_run)
+    _echo_batch_summary(
+        summary,
+        dry_run,
+        json_summary=json_summary,
+        quiet=quiet,
+    )
     _exit_for_summary(ctx, summary, dry_run)
 
 

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import subprocess
@@ -270,6 +271,63 @@ class TestMetadataCleaner(unittest.TestCase):
             self.assertIn("Summary: succeeded=1, failed=1, skipped=0, total=2", result.output)
             self.assertIn("Failed:", result.output)
 
+    def test_cli_json_summary_for_batch(self):
+        """Batch delete should support machine-readable summaries."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            os.makedirs("inputs", exist_ok=True)
+            Image.new("RGB", (10, 10), color="green").save(
+                os.path.join("inputs", "photo.jpg"),
+                "jpeg",
+            )
+
+            result = runner.invoke(
+                cli,
+                ["delete", "inputs", "--output", "outputs", "--json-summary"],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["status"], "success")
+            self.assertFalse(payload["dry_run"])
+            self.assertEqual(payload["total"], 1)
+            self.assertEqual(payload["succeeded"], 1)
+            self.assertEqual(payload["failed"], 0)
+            self.assertEqual(payload["failures"], [])
+
+    def test_cli_json_summary_for_dry_run_with_quiet(self):
+        """JSON summary and quiet mode should produce clean stdout for automation."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            os.makedirs("inputs", exist_ok=True)
+            Image.new("RGB", (10, 10), color="green").save(
+                os.path.join("inputs", "photo.jpg"),
+                "jpeg",
+            )
+
+            result = runner.invoke(
+                cli,
+                ["delete", "inputs", "--json-summary", "--quiet", "--dry-run"],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["status"], "success")
+            self.assertTrue(payload["dry_run"])
+            self.assertEqual(payload["total"], 1)
+            self.assertEqual(payload["would_process"], 1)
+
+    def test_cli_quiet_suppresses_human_success_output(self):
+        """Quiet mode should suppress human output when JSON is not requested."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Image.new("RGB", (10, 10), color="yellow").save("photo.jpg", "jpeg")
+
+            result = runner.invoke(cli, ["delete", "photo.jpg", "--dry-run", "--quiet"])
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertEqual(result.output, "")
+
     def test_cli_no_supported_files_exit_code(self):
         """CLI should distinguish no-op input from successful work."""
         runner = CliRunner()
@@ -282,6 +340,24 @@ class TestMetadataCleaner(unittest.TestCase):
 
             self.assertEqual(result.exit_code, 2, result.output)
             self.assertIn("No supported files found.", result.output)
+
+    def test_cli_no_supported_files_json_summary(self):
+        """JSON summaries should describe empty supported-file sets."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            os.makedirs("inputs", exist_ok=True)
+            with open(os.path.join("inputs", "notes.unknown"), "w") as notes:
+                notes.write("nothing to clean")
+
+            result = runner.invoke(
+                cli,
+                ["delete", "inputs", "--json-summary", "--quiet", "--dry-run"],
+            )
+
+            self.assertEqual(result.exit_code, 2, result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["status"], "no_supported_files")
+            self.assertEqual(payload["total"], 0)
 
     def test_cli_verbose_log_file_option(self):
         """Global CLI options should enable explicit file logging."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.3.1"
+version = "3.4.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add metadata-cleaner delete --json-summary for machine-readable single-file and batch summaries
- add metadata-cleaner delete --quiet for automation-friendly output
- update the release workflow to attach the matching RELEASE_NOTES.md section to each GitHub Release
- bump package version to v3.4.0

## Verification
- poetry check --lock
- pytest: 23 passed, 1 skipped
- flake8 m_c manage.py
- git diff --check
- poetry build: metadata_cleaner-3.4.0
- pip-audit: no known vulnerabilities found; local metadata-cleaner package skipped as expected
- release-note extraction check for v3.4.0