### PR TITLE
feat: add JSON metadata view output

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ View metadata:
 metadata-cleaner view sample.jpg
 ```
 
+Print metadata for automation:
+
+```bash
+metadata-cleaner view sample.jpg --json
+```
+
 Remove metadata from one file:
 
 ```bash

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## v3.5.0
+**Release Date**: 2026-05-10
+
+### Features
+- Added `metadata-cleaner view --json` for stable machine-readable metadata
+  inspection, including invalid-input and no-metadata cases.
+
+### Maintenance
+- Improved CLI metadata formatting so non-JSON-native metadata values are
+  rendered safely instead of causing formatting errors.
+
 ## v3.4.0
 **Release Date**: 2026-05-10
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -52,3 +52,9 @@ The CLI returns stable exit codes for automation:
 - `1`: processing failure.
 - `2`: invalid input, usage error, or no supported files.
 - `3`: partial batch failure.
+
+## Machine-Readable CLI Output
+
+Use `metadata-cleaner view FILE --json` to get a stable JSON envelope with
+`status`, `file`, `metadata_count`, and `metadata` fields. Invalid file input
+returns exit code `2` with `status` set to `invalid_input`.

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -14,7 +14,7 @@ privacy risk before implementation.
 
 ### CLI Usability
 - Add richer batch reports that can be exported to files.
-- Add more machine-readable command output for metadata inspection.
+- Add optional file output targets for machine-readable command output.
 
 ### File Format Support
 - Evaluate HEIC/HEIF support with a clear dependency strategy.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -35,6 +35,12 @@ View metadata:
 metadata-cleaner view my_photo.jpg
 ```
 
+Print metadata in a stable JSON envelope:
+
+```bash
+metadata-cleaner view my_photo.jpg --json
+```
+
 Remove metadata from one file:
 
 ```bash

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -51,6 +51,20 @@ def _summary_payload(summary: BatchSummary, dry_run: bool) -> dict:
     }
 
 
+def _metadata_payload(file_path: str, metadata: Optional[dict], status: str) -> dict:
+    metadata = metadata or {}
+    return {
+        "status": status,
+        "file": file_path,
+        "metadata_count": len(metadata),
+        "metadata": metadata,
+    }
+
+
+def _echo_json(payload: dict) -> None:
+    click.echo(json.dumps(payload, default=str, sort_keys=True))
+
+
 def _echo_batch_summary(
     summary: BatchSummary,
     dry_run: bool,
@@ -58,7 +72,7 @@ def _echo_batch_summary(
     quiet: bool = False,
 ) -> None:
     if json_summary:
-        click.echo(json.dumps(_summary_payload(summary, dry_run), sort_keys=True))
+        _echo_json(_summary_payload(summary, dry_run))
         return
 
     if quiet:
@@ -137,15 +151,26 @@ def cli(verbose, log_file):
 
 @cli.command()
 @click.argument("file")
+@click.option("--json", "json_output", is_flag=True, help="Print a JSON metadata payload.")
 @click.pass_context
-def view(ctx, file):
+def view(ctx, file, json_output):
     """View metadata of a file."""
     if not os.path.isfile(file):
-        click.echo("Error: file does not exist or is not a regular file.")
+        message = "file does not exist or is not a regular file"
+        if json_output:
+            payload = _metadata_payload(file, {}, "invalid_input")
+            payload["error"] = message
+            _echo_json(payload)
+        else:
+            click.echo(f"Error: {message}.")
         ctx.exit(EXIT_USAGE)
 
     metadata = MetadataProcessor().view_metadata(file)
-    click.echo(format_metadata_output(metadata))
+    if json_output:
+        status = "success" if metadata else "no_metadata"
+        _echo_json(_metadata_payload(file, metadata, status))
+    else:
+        click.echo(format_metadata_output(metadata))
 
 
 @cli.command()

--- a/m_c/cli/utils.py
+++ b/m_c/cli/utils.py
@@ -6,7 +6,7 @@ def format_metadata_output(metadata):
     """Formats metadata output for CLI display with error handling."""
     try:
         if metadata:
-            return json.dumps(metadata, indent=4)
+            return json.dumps(metadata, default=str, indent=4)
         return "No metadata found or unsupported file format."
     except (TypeError, ValueError) as e:
         logger.error(f"Error formatting metadata output: {e}")

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -90,6 +90,38 @@ class TestMetadataCleaner(unittest.TestCase):
         pdf_meta = self.processor.view_metadata(self.test_files["document"])
         self.assertIsInstance(pdf_meta, dict)
 
+    def test_cli_view_json_output_with_metadata(self):
+        """View command should provide a stable JSON envelope."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            writer = pypdf.PdfWriter()
+            writer.add_blank_page(width=72, height=72)
+            writer.add_metadata({"/Title": "Automation Test"})
+            with open("sample.pdf", "wb") as pdf_file:
+                writer.write(pdf_file)
+
+            result = runner.invoke(cli, ["view", "sample.pdf", "--json"])
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["status"], "success")
+            self.assertEqual(payload["file"], "sample.pdf")
+            self.assertGreaterEqual(payload["metadata_count"], 1)
+            self.assertIn("/Title", payload["metadata"])
+
+    def test_cli_view_json_output_for_invalid_file(self):
+        """JSON view output should stay parseable for invalid input."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli, ["view", "missing.jpg", "--json"])
+
+            self.assertEqual(result.exit_code, 2, result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["status"], "invalid_input")
+            self.assertEqual(payload["file"], "missing.jpg")
+            self.assertEqual(payload["metadata"], {})
+            self.assertIn("error", payload)
+
     def test_remove_metadata(self):
         """Test metadata removal for all file types while preserving originals."""
         for category, file_path in self.test_files.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.4.0"
+version = "3.5.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add metadata-cleaner view --json with a stable machine-readable envelope
- return parseable JSON for invalid file input and no-metadata cases
- make CLI metadata formatting handle non-JSON-native values safely
- bump package version to v3.5.0 and add curated release notes

## Verification
- poetry check --lock
- pytest: 25 passed, 1 skipped
- flake8 m_c manage.py
- git diff --check
- poetry build: metadata_cleaner-3.5.0
- pip-audit: no known vulnerabilities found; local metadata-cleaner package skipped as expected
- release-note extraction check for v3.5.0