### PR TITLE
feat: add delete summary file output

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ Preview a run without writing files:
 metadata-cleaner delete ./photos --dry-run
 ```
 
+Write a JSON summary report:
+
+```bash
+metadata-cleaner delete ./photos --summary-file reports/summary.json
+```
+
 Edit metadata where supported:
 
 ```bash

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v3.6.0
+**Release Date**: 2026-05-10
+
+### Features
+- Added `metadata-cleaner delete --summary-file PATH` to write the final
+  delete summary as JSON for audits, scheduled jobs, and CI pipelines.
+- Summary files are written for successful, failed, dry-run, and no-supported-
+  file outcomes.
+
 ## v3.5.0
 **Release Date**: 2026-05-10
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -58,3 +58,7 @@ The CLI returns stable exit codes for automation:
 Use `metadata-cleaner view FILE --json` to get a stable JSON envelope with
 `status`, `file`, `metadata_count`, and `metadata` fields. Invalid file input
 returns exit code `2` with `status` set to `invalid_input`.
+
+Use `metadata-cleaner delete PATH --json-summary` to print a machine-readable
+summary to stdout, or `metadata-cleaner delete PATH --summary-file report.json`
+to write the same summary payload to a file.

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -13,8 +13,8 @@ privacy risk before implementation.
 - Add more package smoke coverage for representative file types.
 
 ### CLI Usability
-- Add richer batch reports that can be exported to files.
 - Add optional file output targets for machine-readable command output.
+- Add richer per-file batch reports with output paths and failure reasons.
 
 ### File Format Support
 - Evaluate HEIC/HEIF support with a clear dependency strategy.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -71,6 +71,12 @@ Print a machine-readable summary:
 metadata-cleaner delete ./images --json-summary
 ```
 
+Write the summary to a JSON file:
+
+```bash
+metadata-cleaner delete ./images --summary-file reports/summary.json
+```
+
 Suppress human progress/output for automation:
 
 ```bash

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -65,6 +65,36 @@ def _echo_json(payload: dict) -> None:
     click.echo(json.dumps(payload, default=str, sort_keys=True))
 
 
+def _write_json_payload(file_path: str, payload: dict) -> bool:
+    try:
+        output_dir = os.path.dirname(os.path.abspath(file_path))
+        os.makedirs(output_dir, exist_ok=True)
+        with open(file_path, "w", encoding="utf-8") as output_file:
+            json.dump(payload, output_file, default=str, indent=2, sort_keys=True)
+            output_file.write("\n")
+        return True
+    except OSError as exc:
+        logger.error(f"Failed to write JSON output to {file_path}: {exc}")
+        return False
+
+
+def _write_summary_file(
+    summary_file: Optional[str],
+    summary: BatchSummary,
+    dry_run: bool,
+    quiet: bool = False,
+) -> bool:
+    if not summary_file:
+        return True
+
+    if _write_json_payload(summary_file, _summary_payload(summary, dry_run)):
+        return True
+
+    if not quiet:
+        click.echo(f"Failed to write summary file: {summary_file}")
+    return False
+
+
 def _echo_batch_summary(
     summary: BatchSummary,
     dry_run: bool,
@@ -178,16 +208,25 @@ def view(ctx, file, json_output):
 @click.option("--output", default=None, help="Output file path or batch directory.")
 @click.option("--dry-run", is_flag=True, help="Show what would be processed.")
 @click.option("--json-summary", is_flag=True, help="Print final summary as JSON.")
+@click.option(
+    "--summary-file",
+    type=click.Path(dir_okay=False, path_type=str),
+    default=None,
+    help="Write final summary as JSON to a file.",
+)
 @click.option("--quiet", is_flag=True, help="Suppress progress and human output.")
 @click.pass_context
-def delete(ctx, path, output, dry_run, json_summary, quiet):
+def delete(ctx, path, output, dry_run, json_summary, summary_file, quiet):
     """Remove metadata from a file or supported files in a directory."""
     files_to_process = get_supported_files(path)
     if not files_to_process:
+        summary = BatchSummary(total=0)
         if json_summary:
-            _echo_batch_summary(BatchSummary(total=0), dry_run, json_summary=True)
+            _echo_batch_summary(summary, dry_run, json_summary=True)
         elif not quiet:
             click.echo("No supported files found.")
+        if not _write_summary_file(summary_file, summary, dry_run, quiet):
+            ctx.exit(EXIT_FAILURE)
         ctx.exit(EXIT_USAGE)
 
     processor = MetadataProcessor()
@@ -200,6 +239,8 @@ def delete(ctx, path, output, dry_run, json_summary, quiet):
                 _echo_batch_summary(summary, dry_run, json_summary=True)
             elif not quiet:
                 click.echo("Dry run complete. No files changed.")
+            if not _write_summary_file(summary_file, summary, dry_run, quiet):
+                ctx.exit(EXIT_FAILURE)
             ctx.exit(EXIT_SUCCESS)
         elif result:
             summary.succeeded = 1
@@ -207,6 +248,8 @@ def delete(ctx, path, output, dry_run, json_summary, quiet):
                 _echo_batch_summary(summary, dry_run, json_summary=True)
             elif not quiet:
                 click.echo(f"Metadata removed: {result}")
+            if not _write_summary_file(summary_file, summary, dry_run, quiet):
+                ctx.exit(EXIT_FAILURE)
             ctx.exit(EXIT_SUCCESS)
         else:
             summary.failed = 1
@@ -215,6 +258,8 @@ def delete(ctx, path, output, dry_run, json_summary, quiet):
                 _echo_batch_summary(summary, dry_run, json_summary=True)
             elif not quiet:
                 click.echo("Metadata removal failed. Check logs for details.")
+            if not _write_summary_file(summary_file, summary, dry_run, quiet):
+                ctx.exit(EXIT_FAILURE)
             ctx.exit(EXIT_FAILURE)
 
     summary = BatchSummary(total=len(files_to_process))
@@ -251,6 +296,8 @@ def delete(ctx, path, output, dry_run, json_summary, quiet):
         json_summary=json_summary,
         quiet=quiet,
     )
+    if not _write_summary_file(summary_file, summary, dry_run, quiet):
+        ctx.exit(EXIT_FAILURE)
     _exit_for_summary(ctx, summary, dry_run)
 
 

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -327,6 +327,62 @@ class TestMetadataCleaner(unittest.TestCase):
             self.assertEqual(payload["failed"], 0)
             self.assertEqual(payload["failures"], [])
 
+    def test_cli_summary_file_for_batch(self):
+        """Batch delete should write machine-readable summaries to a file."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            os.makedirs("inputs", exist_ok=True)
+            Image.new("RGB", (10, 10), color="green").save(
+                os.path.join("inputs", "photo.jpg"),
+                "jpeg",
+            )
+
+            result = runner.invoke(
+                cli,
+                [
+                    "delete",
+                    "inputs",
+                    "--output",
+                    "outputs",
+                    "--summary-file",
+                    "reports/summary.json",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertIn("Summary: succeeded=1, failed=0, skipped=0, total=1", result.output)
+            with open(os.path.join("reports", "summary.json")) as summary_file:
+                payload = json.load(summary_file)
+            self.assertEqual(payload["status"], "success")
+            self.assertFalse(payload["dry_run"])
+            self.assertEqual(payload["total"], 1)
+            self.assertEqual(payload["succeeded"], 1)
+
+    def test_cli_summary_file_with_json_summary(self):
+        """Summary files should work alongside JSON stdout."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Image.new("RGB", (10, 10), color="yellow").save("photo.jpg", "jpeg")
+
+            result = runner.invoke(
+                cli,
+                [
+                    "delete",
+                    "photo.jpg",
+                    "--json-summary",
+                    "--summary-file",
+                    "summary.json",
+                    "--dry-run",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            stdout_payload = json.loads(result.output)
+            with open("summary.json") as summary_file:
+                file_payload = json.load(summary_file)
+            self.assertEqual(file_payload, stdout_payload)
+            self.assertEqual(file_payload["would_process"], 1)
+
     def test_cli_json_summary_for_dry_run_with_quiet(self):
         """JSON summary and quiet mode should produce clean stdout for automation."""
         runner = CliRunner()
@@ -388,6 +444,26 @@ class TestMetadataCleaner(unittest.TestCase):
 
             self.assertEqual(result.exit_code, 2, result.output)
             payload = json.loads(result.output)
+            self.assertEqual(payload["status"], "no_supported_files")
+            self.assertEqual(payload["total"], 0)
+
+    def test_cli_no_supported_files_summary_file(self):
+        """Summary files should be written for no-supported-file exits."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            os.makedirs("inputs", exist_ok=True)
+            with open(os.path.join("inputs", "notes.unknown"), "w") as notes:
+                notes.write("nothing to clean")
+
+            result = runner.invoke(
+                cli,
+                ["delete", "inputs", "--summary-file", "summary.json", "--quiet"],
+            )
+
+            self.assertEqual(result.exit_code, 2, result.output)
+            self.assertEqual(result.output, "")
+            with open("summary.json") as summary_file:
+                payload = json.load(summary_file)
             self.assertEqual(payload["status"], "no_supported_files")
             self.assertEqual(payload["total"], 0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.5.0"
+version = "3.6.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add metadata-cleaner delete --summary-file PATH for JSON summary report files
- write summary files for success, failure, dry-run, and no-supported-file outcomes
- keep existing human and JSON stdout behavior intact
- bump package version to v3.6.0 and add curated release notes

## Verification
- poetry check --lock
- pytest: 28 passed, 1 skipped
- flake8 m_c manage.py
- git diff --check
- poetry build: metadata_cleaner-3.6.0
- pip-audit: no known vulnerabilities found; local metadata-cleaner package skipped as expected
- release-note extraction check for v3.6.0