### PR TITLE
feat: add per-file batch report details

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Write a JSON summary report:
 metadata-cleaner delete ./photos --summary-file reports/summary.json
 ```
 
+Summary reports include per-file status and output paths for audit trails.
+
 Edit metadata where supported:
 
 ```bash

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## v3.7.0
+**Release Date**: 2026-05-10
+
+### Features
+- Added per-file details to delete JSON summaries and summary files.
+- Each processed file now reports its input path, status, output path, and
+  failure reason when available.
+
 ## v3.6.0
 **Release Date**: 2026-05-10
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -61,4 +61,6 @@ returns exit code `2` with `status` set to `invalid_input`.
 
 Use `metadata-cleaner delete PATH --json-summary` to print a machine-readable
 summary to stdout, or `metadata-cleaner delete PATH --summary-file report.json`
-to write the same summary payload to a file.
+to write the same summary payload to a file. Delete summaries include top-level
+counts plus a `files` list with each input path, per-file status, output path,
+and failure reason when available.

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -14,7 +14,8 @@ privacy risk before implementation.
 
 ### CLI Usability
 - Add optional file output targets for machine-readable command output.
-- Add richer per-file batch reports with output paths and failure reasons.
+- Add configurable verbosity levels for per-file report payloads if users need
+  compact reports for very large batches.
 
 ### File Format Support
 - Evaluate HEIC/HEIF support with a clear dependency strategy.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -77,6 +77,23 @@ Write the summary to a JSON file:
 metadata-cleaner delete ./images --summary-file reports/summary.json
 ```
 
+JSON summaries include top-level counts and per-file details:
+
+```json
+{
+  "status": "partial_failure",
+  "succeeded": 12,
+  "failed": 1,
+  "files": [
+    {
+      "input": "images/photo.jpg",
+      "status": "success",
+      "output": "cleaned-images/photo.jpg"
+    }
+  ]
+}
+```
+
 Suppress human progress/output for automation:
 
 ```bash

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -24,6 +24,7 @@ class BatchSummary:
     failed: int = 0
     skipped: int = 0
     failures: list[str] = field(default_factory=list)
+    files: list[dict] = field(default_factory=list)
 
 
 def _summary_status(summary: BatchSummary, dry_run: bool) -> str:
@@ -48,6 +49,7 @@ def _summary_payload(summary: BatchSummary, dry_run: bool) -> dict:
         "skipped": summary.skipped,
         "would_process": summary.succeeded if dry_run else None,
         "failures": summary.failures,
+        "files": summary.files,
     }
 
 
@@ -166,6 +168,29 @@ def _batch_output_path(
     return get_safe_output_path(target_path, create_dirs=create_dirs)
 
 
+def _single_output_path(file_path: str, output_path: Optional[str]) -> str:
+    if output_path:
+        return output_path
+    return os.path.join(os.path.dirname(file_path), "cleaned", os.path.basename(file_path))
+
+
+def _record_file_result(
+    summary: BatchSummary,
+    input_path: str,
+    status: str,
+    output_path: Optional[str] = None,
+    error: Optional[str] = None,
+) -> None:
+    item = {
+        "input": input_path,
+        "status": status,
+        "output": output_path,
+    }
+    if error:
+        item["error"] = error
+    summary.files.append(item)
+
+
 @click.group()
 @click.option("--verbose", is_flag=True, help="Enable debug logging.")
 @click.option(
@@ -231,10 +256,18 @@ def delete(ctx, path, output, dry_run, json_summary, summary_file, quiet):
 
     processor = MetadataProcessor()
     if len(files_to_process) == 1 and not os.path.isdir(path):
-        result = processor.delete_metadata(files_to_process[0], output, dry_run=dry_run)
+        input_file = files_to_process[0]
+        planned_output = _single_output_path(input_file, output)
+        result = processor.delete_metadata(input_file, output, dry_run=dry_run)
         summary = BatchSummary(total=1)
         if dry_run:
             summary.succeeded = 1
+            _record_file_result(
+                summary,
+                input_file,
+                "would_process",
+                planned_output,
+            )
             if json_summary:
                 _echo_batch_summary(summary, dry_run, json_summary=True)
             elif not quiet:
@@ -244,6 +277,7 @@ def delete(ctx, path, output, dry_run, json_summary, summary_file, quiet):
             ctx.exit(EXIT_SUCCESS)
         elif result:
             summary.succeeded = 1
+            _record_file_result(summary, input_file, "success", result)
             if json_summary:
                 _echo_batch_summary(summary, dry_run, json_summary=True)
             elif not quiet:
@@ -253,7 +287,14 @@ def delete(ctx, path, output, dry_run, json_summary, summary_file, quiet):
             ctx.exit(EXIT_SUCCESS)
         else:
             summary.failed = 1
-            summary.failures.append(files_to_process[0])
+            summary.failures.append(input_file)
+            _record_file_result(
+                summary,
+                input_file,
+                "failed",
+                planned_output,
+                "metadata_removal_failed",
+            )
             if json_summary:
                 _echo_batch_summary(summary, dry_run, json_summary=True)
             elif not quiet:
@@ -281,12 +322,32 @@ def delete(ctx, path, output, dry_run, json_summary, summary_file, quiet):
                 )
                 if result or dry_run:
                     summary.succeeded += 1
+                    _record_file_result(
+                        summary,
+                        file_path,
+                        "would_process" if dry_run else "success",
+                        output_path if dry_run else result,
+                    )
                 else:
                     summary.failed += 1
                     summary.failures.append(file_path)
+                    _record_file_result(
+                        summary,
+                        file_path,
+                        "failed",
+                        output_path,
+                        "metadata_removal_failed",
+                    )
             except Exception as e:
                 summary.failed += 1
                 summary.failures.append(file_path)
+                _record_file_result(
+                    summary,
+                    file_path,
+                    "failed",
+                    None,
+                    str(e),
+                )
                 logger.error(f"Failed to process {file_path}: {e}", exc_info=True)
             pbar.update(1)
 

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -326,6 +326,42 @@ class TestMetadataCleaner(unittest.TestCase):
             self.assertEqual(payload["succeeded"], 1)
             self.assertEqual(payload["failed"], 0)
             self.assertEqual(payload["failures"], [])
+            self.assertEqual(len(payload["files"]), 1)
+            self.assertEqual(payload["files"][0]["input"], os.path.join("inputs", "photo.jpg"))
+            self.assertEqual(payload["files"][0]["status"], "success")
+            self.assertTrue(payload["files"][0]["output"].startswith("outputs"))
+
+    def test_cli_json_summary_for_batch_partial_failure_has_file_details(self):
+        """JSON batch summaries should include per-file status and errors."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            os.makedirs("inputs", exist_ok=True)
+            Image.new("RGB", (10, 10), color="green").save(
+                os.path.join("inputs", "photo.jpg"),
+                "jpeg",
+            )
+            with open(os.path.join("inputs", "broken.pdf"), "wb") as broken_pdf:
+                broken_pdf.write(b"not a valid pdf")
+
+            result = runner.invoke(
+                cli,
+                ["delete", "inputs", "--output", "outputs", "--json-summary"],
+            )
+
+            self.assertEqual(result.exit_code, 3, result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["status"], "partial_failure")
+            self.assertEqual(payload["succeeded"], 1)
+            self.assertEqual(payload["failed"], 1)
+            self.assertEqual(len(payload["files"]), 2)
+            files_by_input = {item["input"]: item for item in payload["files"]}
+            self.assertEqual(
+                files_by_input[os.path.join("inputs", "photo.jpg")]["status"],
+                "success",
+            )
+            failed_item = files_by_input[os.path.join("inputs", "broken.pdf")]
+            self.assertEqual(failed_item["status"], "failed")
+            self.assertEqual(failed_item["error"], "metadata_removal_failed")
 
     def test_cli_summary_file_for_batch(self):
         """Batch delete should write machine-readable summaries to a file."""
@@ -357,6 +393,12 @@ class TestMetadataCleaner(unittest.TestCase):
             self.assertFalse(payload["dry_run"])
             self.assertEqual(payload["total"], 1)
             self.assertEqual(payload["succeeded"], 1)
+            self.assertEqual(payload["files"][0]["status"], "success")
+            self.assertEqual(
+                payload["files"][0]["input"],
+                os.path.join("inputs", "photo.jpg"),
+            )
+            self.assertTrue(payload["files"][0]["output"].startswith("outputs"))
 
     def test_cli_summary_file_with_json_summary(self):
         """Summary files should work alongside JSON stdout."""
@@ -382,6 +424,11 @@ class TestMetadataCleaner(unittest.TestCase):
                 file_payload = json.load(summary_file)
             self.assertEqual(file_payload, stdout_payload)
             self.assertEqual(file_payload["would_process"], 1)
+            self.assertEqual(file_payload["files"][0]["status"], "would_process")
+            self.assertEqual(
+                file_payload["files"][0]["output"],
+                os.path.join("cleaned", "photo.jpg"),
+            )
 
     def test_cli_json_summary_for_dry_run_with_quiet(self):
         """JSON summary and quiet mode should produce clean stdout for automation."""
@@ -404,6 +451,8 @@ class TestMetadataCleaner(unittest.TestCase):
             self.assertTrue(payload["dry_run"])
             self.assertEqual(payload["total"], 1)
             self.assertEqual(payload["would_process"], 1)
+            self.assertEqual(payload["files"][0]["status"], "would_process")
+            self.assertTrue(payload["files"][0]["output"].startswith("inputs"))
 
     def test_cli_quiet_suppresses_human_success_output(self):
         """Quiet mode should suppress human output when JSON is not requested."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.6.0"
+version = "3.7.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add per-file details to delete JSON summaries and summary files
- report input path, per-file status, output path, and failure reason where available
- keep existing top-level summary counts and exit-code behavior intact
- bump package version to v3.7.0 and add curated release notes

## Verification
- poetry check --lock
- pytest: 29 passed, 1 skipped
- flake8 m_c manage.py
- git diff --check
- poetry build: metadata_cleaner-3.7.0
- pip-audit: no known vulnerabilities found; local metadata-cleaner package skipped as expected
- release-note extraction check for v3.7.0