### PR TITLE
ci: expand package smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,50 @@ jobs:
         run: |
           /tmp/metadata-cleaner-smoke/bin/metadata-cleaner --help
           /tmp/metadata-cleaner-smoke/bin/python - <<'PY'
+          import os
+          import wave
+
+          import docx
           from PIL import Image
-          Image.new("RGB", (8, 8), color="white").save("smoke.jpg", "jpeg")
+          import pypdf
+
+          os.makedirs("smoke-files", exist_ok=True)
+
+          Image.new("RGB", (8, 8), color="white").save(
+              "smoke-files/photo.jpg",
+              "jpeg",
+          )
+
+          writer = pypdf.PdfWriter()
+          writer.add_blank_page(width=72, height=72)
+          writer.add_metadata({"/Title": "Smoke PDF"})
+          with open("smoke-files/document.pdf", "wb") as pdf_file:
+              writer.write(pdf_file)
+
+          document = docx.Document()
+          document.add_paragraph("Metadata Cleaner smoke document.")
+          document.core_properties.title = "Smoke DOCX"
+          document.save("smoke-files/document.docx")
+
+          with wave.open("smoke-files/audio.wav", "wb") as wav_file:
+              wav_file.setnchannels(1)
+              wav_file.setsampwidth(2)
+              wav_file.setframerate(8000)
+              wav_file.writeframes(b"\0\0" * 800)
           PY
-          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner view smoke.jpg
-          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner delete smoke.jpg --dry-run
+          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner view smoke-files/photo.jpg --json
+          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner view smoke-files/document.pdf --json
+          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner view smoke-files/document.docx --json
+          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner view smoke-files/audio.wav --json
+          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner delete smoke-files --dry-run --json-summary
+          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner delete smoke-files --output smoke-cleaned --summary-file smoke-report.json --quiet
+          /tmp/metadata-cleaner-smoke/bin/python - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = json.loads(Path("smoke-report.json").read_text())
+          assert report["status"] == "success", report
+          assert report["total"] == 4, report
+          assert report["succeeded"] == 4, report
+          assert len(report["files"]) == 4, report
+          PY

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v3.7.2
+**Release Date**: 2026-05-10
+
+### Maintenance
+- Expanded the installed-package smoke test to exercise JPEG, PDF, DOCX, and
+  WAV files through the packaged `metadata-cleaner` CLI.
+- Added smoke assertions for JSON metadata views, dry-run summaries, real
+  cleaning output, and generated summary reports.
+
 ## v3.7.1
 **Release Date**: 2026-05-10
 

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -9,9 +9,10 @@ privacy risk before implementation.
 
 ### Stronger Fixture Coverage
 - Add video integration tests that run when FFmpeg and FFprobe are installed.
-- Add more package smoke coverage for representative file types.
 - Add fixture assertions for additional audio containers beyond WAV when their
   metadata can be generated without external system tools.
+- Add installed-package smoke coverage for optional system-tool paths when
+  those tools are available in CI.
 
 ### CLI Usability
 - Add optional file output targets for machine-readable command output.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.7.1"
+version = "3.7.2"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- expand installed-wheel smoke coverage across JPEG, PDF, DOCX, and WAV fixtures
- run JSON metadata views, dry-run delete summaries, real cleaning, and summary-file assertions through the packaged CLI
- bump package version to v3.7.2 and add curated release notes

## Verification
- poetry check --lock
- pytest: 29 passed, 1 skipped
- flake8 m_c manage.py
- git diff --check
- poetry build: metadata_cleaner-3.7.2
- pip-audit: no known vulnerabilities found; local metadata-cleaner package skipped as expected
- release-note extraction check for v3.7.2