### PR TITLE
feat: add checksum reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ metadata-cleaner delete ./photos --summary-file reports/summary.json
 ```
 
 Summary reports include per-file status and output paths for audit trails.
+Add `--checksums` to include SHA-256 input/output hashes.
 
 Edit metadata where supported:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v3.8.0
+**Release Date**: 2026-05-10
+
+### Features
+- Added `metadata-cleaner delete --checksums` to include SHA-256 integrity
+  hashes in JSON summaries and summary files.
+- Checksum reporting covers input files for dry runs and both input/output
+  files for completed cleaning operations.
+
 ## v3.7.2
 **Release Date**: 2026-05-10
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -64,3 +64,8 @@ summary to stdout, or `metadata-cleaner delete PATH --summary-file report.json`
 to write the same summary payload to a file. Delete summaries include top-level
 counts plus a `files` list with each input path, per-file status, output path,
 and failure reason when available.
+
+Pass `--checksums` with `delete` to include SHA-256 hashes in each per-file
+result. Dry-run summaries include input hashes and leave output hashes empty;
+completed cleaning summaries include both input and output hashes when files are
+available.

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -27,11 +27,11 @@ privacy risk before implementation.
 ## Medium Term
 
 ### Privacy and Safety
-- Add optional checksum reporting for input/output integrity checks.
 - Add a `--preserve-timestamps` option if users need cleaned files to retain
   filesystem timestamps.
 - Add clearer warnings for formats that require re-saving rather than lossless
   metadata stripping.
+- Add optional checksum algorithms beyond SHA-256 only if users need them.
 
 ### Packaging
 - Add a Docker image publishing workflow after Docker builds are covered in CI.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -77,6 +77,12 @@ Write the summary to a JSON file:
 metadata-cleaner delete ./images --summary-file reports/summary.json
 ```
 
+Include SHA-256 checksums in JSON summaries:
+
+```bash
+metadata-cleaner delete ./images --summary-file reports/summary.json --checksums
+```
+
 JSON summaries include top-level counts and per-file details:
 
 ```json
@@ -88,7 +94,11 @@ JSON summaries include top-level counts and per-file details:
     {
       "input": "images/photo.jpg",
       "status": "success",
-      "output": "cleaned-images/photo.jpg"
+      "output": "cleaned-images/photo.jpg",
+      "checksums": {
+        "input_sha256": "<sha256>",
+        "output_sha256": "<sha256>"
+      }
     }
   ]
 }

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -7,7 +7,11 @@ import click
 from tqdm import tqdm
 
 from m_c.cli.utils import format_metadata_output
-from m_c.core.file_utils import get_safe_output_path, get_supported_files
+from m_c.core.file_utils import (
+    get_file_checksum,
+    get_safe_output_path,
+    get_supported_files,
+)
 from m_c.core.logger import configure_logging, logger
 from m_c.core.metadata_processor import MetadataProcessor
 
@@ -180,12 +184,22 @@ def _record_file_result(
     status: str,
     output_path: Optional[str] = None,
     error: Optional[str] = None,
+    include_checksums: bool = False,
 ) -> None:
     item = {
         "input": input_path,
         "status": status,
         "output": output_path,
     }
+    if include_checksums:
+        item["checksums"] = {
+            "input_sha256": get_file_checksum(input_path),
+            "output_sha256": (
+                get_file_checksum(output_path)
+                if output_path and os.path.exists(output_path)
+                else None
+            ),
+        }
     if error:
         item["error"] = error
     summary.files.append(item)
@@ -234,6 +248,11 @@ def view(ctx, file, json_output):
 @click.option("--dry-run", is_flag=True, help="Show what would be processed.")
 @click.option("--json-summary", is_flag=True, help="Print final summary as JSON.")
 @click.option(
+    "--checksums",
+    is_flag=True,
+    help="Include SHA-256 checksums in JSON summaries and summary files.",
+)
+@click.option(
     "--summary-file",
     type=click.Path(dir_okay=False, path_type=str),
     default=None,
@@ -241,7 +260,7 @@ def view(ctx, file, json_output):
 )
 @click.option("--quiet", is_flag=True, help="Suppress progress and human output.")
 @click.pass_context
-def delete(ctx, path, output, dry_run, json_summary, summary_file, quiet):
+def delete(ctx, path, output, dry_run, json_summary, checksums, summary_file, quiet):
     """Remove metadata from a file or supported files in a directory."""
     files_to_process = get_supported_files(path)
     if not files_to_process:
@@ -267,6 +286,7 @@ def delete(ctx, path, output, dry_run, json_summary, summary_file, quiet):
                 input_file,
                 "would_process",
                 planned_output,
+                include_checksums=checksums,
             )
             if json_summary:
                 _echo_batch_summary(summary, dry_run, json_summary=True)
@@ -277,7 +297,13 @@ def delete(ctx, path, output, dry_run, json_summary, summary_file, quiet):
             ctx.exit(EXIT_SUCCESS)
         elif result:
             summary.succeeded = 1
-            _record_file_result(summary, input_file, "success", result)
+            _record_file_result(
+                summary,
+                input_file,
+                "success",
+                result,
+                include_checksums=checksums,
+            )
             if json_summary:
                 _echo_batch_summary(summary, dry_run, json_summary=True)
             elif not quiet:
@@ -294,6 +320,7 @@ def delete(ctx, path, output, dry_run, json_summary, summary_file, quiet):
                 "failed",
                 planned_output,
                 "metadata_removal_failed",
+                include_checksums=checksums,
             )
             if json_summary:
                 _echo_batch_summary(summary, dry_run, json_summary=True)
@@ -327,6 +354,7 @@ def delete(ctx, path, output, dry_run, json_summary, summary_file, quiet):
                         file_path,
                         "would_process" if dry_run else "success",
                         output_path if dry_run else result,
+                        include_checksums=checksums,
                     )
                 else:
                     summary.failed += 1
@@ -337,6 +365,7 @@ def delete(ctx, path, output, dry_run, json_summary, summary_file, quiet):
                         "failed",
                         output_path,
                         "metadata_removal_failed",
+                        include_checksums=checksums,
                     )
             except Exception as e:
                 summary.failed += 1
@@ -347,6 +376,7 @@ def delete(ctx, path, output, dry_run, json_summary, summary_file, quiet):
                     "failed",
                     None,
                     str(e),
+                    include_checksums=checksums,
                 )
                 logger.error(f"Failed to process {file_path}: {e}", exc_info=True)
             pbar.update(1)

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import shutil
@@ -446,6 +447,55 @@ class TestMetadataCleaner(unittest.TestCase):
                 file_payload["files"][0]["output"],
                 os.path.join("cleaned", "photo.jpg"),
             )
+
+    def test_cli_json_summary_with_checksums_for_dry_run(self):
+        """Checksum reporting should include input hashes without writing outputs."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Image.new("RGB", (10, 10), color="yellow").save("photo.jpg", "jpeg")
+            with open("photo.jpg", "rb") as image_file:
+                expected_hash = hashlib.sha256(image_file.read()).hexdigest()
+
+            result = runner.invoke(
+                cli,
+                ["delete", "photo.jpg", "--dry-run", "--json-summary", "--checksums"],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            checksums = payload["files"][0]["checksums"]
+            self.assertEqual(checksums["input_sha256"], expected_hash)
+            self.assertIsNone(checksums["output_sha256"])
+
+    def test_cli_summary_file_with_checksums_for_cleaned_output(self):
+        """Checksum reporting should include input and cleaned output hashes."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Image.new("RGB", (10, 10), color="yellow").save("photo.jpg", "jpeg")
+
+            result = runner.invoke(
+                cli,
+                [
+                    "delete",
+                    "photo.jpg",
+                    "--output",
+                    "cleaned.jpg",
+                    "--summary-file",
+                    "summary.json",
+                    "--checksums",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            with open("summary.json") as summary_file:
+                payload = json.load(summary_file)
+            checksums = payload["files"][0]["checksums"]
+            with open("photo.jpg", "rb") as input_file:
+                expected_input = hashlib.sha256(input_file.read()).hexdigest()
+            with open("cleaned.jpg", "rb") as output_file:
+                expected_output = hashlib.sha256(output_file.read()).hexdigest()
+            self.assertEqual(checksums["input_sha256"], expected_input)
+            self.assertEqual(checksums["output_sha256"], expected_output)
 
     def test_cli_json_summary_for_dry_run_with_quiet(self):
         """JSON summary and quiet mode should produce clean stdout for automation."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.7.2"
+version = "3.8.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add metadata-cleaner delete --checksums for optional SHA-256 integrity hashes
- include input hashes for dry-run reports and input/output hashes for completed cleaning operations
- document checksum reporting in usage/API docs and update the roadmap
- bump package version to v3.8.0 and add curated release notes

## Verification
- poetry check --lock
- pytest: 31 passed, 1 skipped
- flake8 m_c manage.py
- git diff --check
- poetry build: metadata_cleaner-3.8.0
- pip-audit: no known vulnerabilities found; local metadata-cleaner package skipped as expected
- release-note extraction check for v3.8.0