### PR TITLE
feat: preserve output timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ metadata-cleaner delete ./photos --summary-file reports/summary.json
 
 Summary reports include per-file status and output paths for audit trails.
 Add `--checksums` to include SHA-256 input/output hashes.
+Add `--preserve-timestamps` when cleaned files should keep source file times.
 
 Edit metadata where supported:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v3.9.0
+**Release Date**: 2026-05-10
+
+### Features
+- Added `metadata-cleaner delete --preserve-timestamps` to copy source access
+  and modification times to cleaned outputs.
+- Added programmatic support through
+  `MetadataProcessor.delete_metadata(..., preserve_timestamps=True)`.
+
 ## v3.8.0
 **Release Date**: 2026-05-10
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -14,12 +14,13 @@ metadata = MetadataProcessor().view_metadata("image.jpg")
 print(metadata)
 ```
 
-## `delete_metadata(file_path: str, output_path: str | None = None, dry_run: bool = False) -> str | None`
+## `delete_metadata(file_path: str, output_path: str | None = None, dry_run: bool = False, preserve_timestamps: bool = False) -> str | None`
 
 Remove metadata and write a cleaned copy. When `output_path` is omitted, the
 cleaned file is written under a `cleaned/` directory next to the source file.
 When `dry_run=True`, the method returns `None` and does not create output files
-or directories.
+or directories. Pass `preserve_timestamps=True` to copy the source access and
+modification times to the cleaned file after metadata removal.
 
 ```python
 from m_c.core.metadata_processor import MetadataProcessor

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -27,11 +27,11 @@ privacy risk before implementation.
 ## Medium Term
 
 ### Privacy and Safety
-- Add a `--preserve-timestamps` option if users need cleaned files to retain
-  filesystem timestamps.
 - Add clearer warnings for formats that require re-saving rather than lossless
   metadata stripping.
 - Add optional checksum algorithms beyond SHA-256 only if users need them.
+- Add timestamp preservation coverage for additional handlers as new formats are
+  added.
 
 ### Packaging
 - Add a Docker image publishing workflow after Docker builds are covered in CI.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -83,6 +83,12 @@ Include SHA-256 checksums in JSON summaries:
 metadata-cleaner delete ./images --summary-file reports/summary.json --checksums
 ```
 
+Preserve source access and modification times on cleaned files:
+
+```bash
+metadata-cleaner delete ./images --output ./cleaned-images --preserve-timestamps
+```
+
 JSON summaries include top-level counts and per-file details:
 
 ```json

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -253,6 +253,11 @@ def view(ctx, file, json_output):
     help="Include SHA-256 checksums in JSON summaries and summary files.",
 )
 @click.option(
+    "--preserve-timestamps",
+    is_flag=True,
+    help="Copy source access and modification times to cleaned outputs.",
+)
+@click.option(
     "--summary-file",
     type=click.Path(dir_okay=False, path_type=str),
     default=None,
@@ -260,7 +265,17 @@ def view(ctx, file, json_output):
 )
 @click.option("--quiet", is_flag=True, help="Suppress progress and human output.")
 @click.pass_context
-def delete(ctx, path, output, dry_run, json_summary, checksums, summary_file, quiet):
+def delete(
+    ctx,
+    path,
+    output,
+    dry_run,
+    json_summary,
+    checksums,
+    preserve_timestamps,
+    summary_file,
+    quiet,
+):
     """Remove metadata from a file or supported files in a directory."""
     files_to_process = get_supported_files(path)
     if not files_to_process:
@@ -277,7 +292,12 @@ def delete(ctx, path, output, dry_run, json_summary, checksums, summary_file, qu
     if len(files_to_process) == 1 and not os.path.isdir(path):
         input_file = files_to_process[0]
         planned_output = _single_output_path(input_file, output)
-        result = processor.delete_metadata(input_file, output, dry_run=dry_run)
+        result = processor.delete_metadata(
+            input_file,
+            output,
+            dry_run=dry_run,
+            preserve_timestamps=preserve_timestamps,
+        )
         summary = BatchSummary(total=1)
         if dry_run:
             summary.succeeded = 1
@@ -346,6 +366,7 @@ def delete(ctx, path, output, dry_run, json_summary, checksums, summary_file, qu
                     file_path,
                     output_path,
                     dry_run=dry_run,
+                    preserve_timestamps=preserve_timestamps,
                 )
                 if result or dry_run:
                     summary.succeeded += 1

--- a/m_c/core/metadata_processor.py
+++ b/m_c/core/metadata_processor.py
@@ -35,7 +35,11 @@ class MetadataProcessor:
             return {}
 
     def delete_metadata(
-        self, file_path: str, output_path: Optional[str] = None, dry_run: bool = False
+        self,
+        file_path: str,
+        output_path: Optional[str] = None,
+        dry_run: bool = False,
+        preserve_timestamps: bool = False,
     ) -> Optional[str]:
         """Ensure the cleaned file is correctly saved without modifying the original."""
         if not validate_file(file_path):
@@ -75,6 +79,10 @@ class MetadataProcessor:
                     f"Expected output: {output_path}"
                 )
                 return None
+
+            if preserve_timestamps:
+                source_stat = os.stat(file_path)
+                os.utime(cleaned_file, (source_stat.st_atime, source_stat.st_mtime))
 
             logger.info(f"Metadata successfully removed: {cleaned_file}")
             return cleaned_file

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -248,6 +248,24 @@ class TestMetadataCleaner(unittest.TestCase):
         self.assertIsNone(result)
         self.assertFalse(os.path.exists(default_cleaned_dir))
 
+    def test_delete_metadata_preserves_timestamps_when_requested(self):
+        """Core cleanup should optionally preserve source filesystem timestamps."""
+        source_file = os.path.join(self.test_dir, "timestamped.jpg")
+        cleaned_file = os.path.join(self.cleaned_dir, "timestamped_cleaned.jpg")
+        Image.new("RGB", (10, 10), color="blue").save(source_file, "jpeg")
+        old_atime = 1_600_000_000
+        old_mtime = 1_500_000_000
+        os.utime(source_file, (old_atime, old_mtime))
+
+        result = self.processor.delete_metadata(
+            source_file,
+            cleaned_file,
+            preserve_timestamps=True,
+        )
+
+        self.assertEqual(result, cleaned_file)
+        self.assertEqual(int(os.stat(cleaned_file).st_mtime), old_mtime)
+
     def test_docx_metadata_removal_clears_core_properties(self):
         """DOCX cleaning should preserve content and clear common core metadata."""
         cleaned_docx = os.path.join(self.cleaned_dir, "cleaned_sample.docx")
@@ -496,6 +514,29 @@ class TestMetadataCleaner(unittest.TestCase):
                 expected_output = hashlib.sha256(output_file.read()).hexdigest()
             self.assertEqual(checksums["input_sha256"], expected_input)
             self.assertEqual(checksums["output_sha256"], expected_output)
+
+    def test_cli_delete_preserves_timestamps_when_requested(self):
+        """CLI cleanup should optionally preserve source filesystem timestamps."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Image.new("RGB", (10, 10), color="yellow").save("photo.jpg", "jpeg")
+            old_atime = 1_600_000_000
+            old_mtime = 1_500_000_000
+            os.utime("photo.jpg", (old_atime, old_mtime))
+
+            result = runner.invoke(
+                cli,
+                [
+                    "delete",
+                    "photo.jpg",
+                    "--output",
+                    "cleaned.jpg",
+                    "--preserve-timestamps",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertEqual(int(os.stat("cleaned.jpg").st_mtime), old_mtime)
 
     def test_cli_json_summary_for_dry_run_with_quiet(self):
         """JSON summary and quiet mode should produce clean stdout for automation."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.8.0"
+version = "3.9.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add metadata-cleaner delete --preserve-timestamps for audit-friendly cleaned outputs
- add preserve_timestamps support to MetadataProcessor.delete_metadata
- preserve source access/modification times after successful metadata removal
- bump package version to v3.9.0 and add curated release notes

## Verification
- poetry check --lock
- pytest: 33 passed, 1 skipped
- flake8 m_c manage.py
- git diff --check
- poetry build: metadata_cleaner-3.9.0
- pip-audit: no known vulnerabilities found; local metadata-cleaner package skipped as expected
- release-note extraction check for v3.9.0