### PR TITLE
feat: add processing warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ metadata-cleaner delete ./photos --summary-file reports/summary.json
 Summary reports include per-file status and output paths for audit trails.
 Add `--checksums` to include SHA-256 input/output hashes.
 Add `--preserve-timestamps` when cleaned files should keep source file times.
+Formats that rewrite, re-save, or remux data include per-file warnings in JSON
+summary reports.
 
 Edit metadata where supported:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v3.10.0
+**Release Date**: 2026-05-10
+
+### Features
+- Added per-file processing warnings to delete JSON summaries and summary
+  files for formats that rewrite, re-save, or remux data while removing
+  metadata.
+- Warnings are available during dry runs as well as completed cleaning runs.
+
 ## v3.9.0
 **Release Date**: 2026-05-10
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -64,7 +64,7 @@ Use `metadata-cleaner delete PATH --json-summary` to print a machine-readable
 summary to stdout, or `metadata-cleaner delete PATH --summary-file report.json`
 to write the same summary payload to a file. Delete summaries include top-level
 counts plus a `files` list with each input path, per-file status, output path,
-and failure reason when available.
+format-specific processing warnings, and failure reason when available.
 
 Pass `--checksums` with `delete` to include SHA-256 hashes in each per-file
 result. Dry-run summaries include input hashes and leave output hashes empty;

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -27,11 +27,11 @@ privacy risk before implementation.
 ## Medium Term
 
 ### Privacy and Safety
-- Add clearer warnings for formats that require re-saving rather than lossless
-  metadata stripping.
 - Add optional checksum algorithms beyond SHA-256 only if users need them.
 - Add timestamp preservation coverage for additional handlers as new formats are
   added.
+- Expand per-file warnings as handlers gain more precise lossless/rewrite
+  detection.
 
 ### Packaging
 - Add a Docker image publishing workflow after Docker builds are covered in CI.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -101,6 +101,9 @@ JSON summaries include top-level counts and per-file details:
       "input": "images/photo.jpg",
       "status": "success",
       "output": "cleaned-images/photo.jpg",
+      "warnings": [
+        "Format-specific processing notes appear here when applicable."
+      ],
       "checksums": {
         "input_sha256": "<sha256>",
         "output_sha256": "<sha256>"

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -178,6 +178,38 @@ def _single_output_path(file_path: str, output_path: Optional[str]) -> str:
     return os.path.join(os.path.dirname(file_path), "cleaned", os.path.basename(file_path))
 
 
+def _processing_warnings(file_path: str) -> list[str]:
+    ext = os.path.splitext(file_path)[1].lower()
+    warnings_by_extension = {
+        ".png": [
+            "PNG metadata removal re-saves image data; inspect output if "
+            "pixel-perfect preservation matters."
+        ],
+        ".pdf": [
+            "PDF metadata removal rewrites the document container while "
+            "preserving content."
+        ],
+        ".docx": [
+            "DOCX metadata removal rewrites the document package while "
+            "preserving content."
+        ],
+        ".mp3": ["Audio metadata removal rewrites tags on a copied audio file."],
+        ".wav": ["Audio metadata removal rewrites tags on a copied audio file."],
+        ".flac": ["Audio metadata removal rewrites tags on a copied audio file."],
+        ".ogg": ["Audio metadata removal rewrites tags on a copied audio file."],
+        ".aac": ["Audio metadata removal rewrites tags on a copied audio file."],
+        ".m4a": ["Audio metadata removal rewrites tags on a copied audio file."],
+        ".wma": ["Audio metadata removal rewrites tags on a copied audio file."],
+        ".mp4": ["Video metadata removal remuxes the container with stream copy."],
+        ".mkv": ["Video metadata removal remuxes the container with stream copy."],
+        ".mov": ["Video metadata removal remuxes the container with stream copy."],
+        ".avi": ["Video metadata removal remuxes the container with stream copy."],
+        ".webm": ["Video metadata removal remuxes the container with stream copy."],
+        ".flv": ["Video metadata removal remuxes the container with stream copy."],
+    }
+    return warnings_by_extension.get(ext, [])
+
+
 def _record_file_result(
     summary: BatchSummary,
     input_path: str,
@@ -191,6 +223,9 @@ def _record_file_result(
         "status": status,
         "output": output_path,
     }
+    warnings = _processing_warnings(input_path)
+    if warnings:
+        item["warnings"] = warnings
     if include_checksums:
         item["checksums"] = {
             "input_sha256": get_file_checksum(input_path),

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -485,6 +485,22 @@ class TestMetadataCleaner(unittest.TestCase):
             self.assertEqual(checksums["input_sha256"], expected_hash)
             self.assertIsNone(checksums["output_sha256"])
 
+    def test_cli_json_summary_includes_processing_warnings(self):
+        """JSON summaries should warn when formats use rewrite-style cleanup."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Image.new("RGB", (10, 10), color="yellow").save("photo.png", "png")
+
+            result = runner.invoke(
+                cli,
+                ["delete", "photo.png", "--dry-run", "--json-summary"],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            warnings = payload["files"][0]["warnings"]
+            self.assertTrue(any("re-saves image data" in warning for warning in warnings))
+
     def test_cli_summary_file_with_checksums_for_cleaned_output(self):
         """Checksum reporting should include input and cleaned output hashes."""
         runner = CliRunner()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.9.0"
+version = "3.10.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add per-file processing warnings to delete JSON summaries and summary files
- warn for formats that re-save, rewrite, or remux data during metadata removal
- include warnings during dry runs so users can inspect behavior before writing output
- bump package version to v3.10.0 and add curated release notes

## Verification
- poetry check --lock
- pytest: 34 passed, 1 skipped
- flake8 m_c manage.py
- git diff --check
- poetry build: metadata_cleaner-3.10.0
- pip-audit: no known vulnerabilities found; local metadata-cleaner package skipped as expected
- release-note extraction check for v3.10.0