### PR TITLE
feat: add report detail levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ metadata-cleaner delete ./photos --summary-file reports/summary.json
 Summary reports include per-file status and output paths for audit trails.
 Add `--checksums` to include SHA-256 input/output hashes.
 Add `--preserve-timestamps` when cleaned files should keep source file times.
+Use `--report-detail compact` or `--report-detail summary` for smaller reports.
 Formats that rewrite, re-save, or remux data include per-file warnings in JSON
 summary reports.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v3.11.0
+**Release Date**: 2026-05-10
+
+### Features
+- Added `metadata-cleaner delete --report-detail full|compact|summary` to
+  control JSON summary verbosity for large batch and automation workflows.
+- `full` preserves the existing report shape, `compact` keeps per-file status
+  with minimal fields, and `summary` omits per-file entries entirely.
+
 ## v3.10.0
 **Release Date**: 2026-05-10
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -70,3 +70,7 @@ Pass `--checksums` with `delete` to include SHA-256 hashes in each per-file
 result. Dry-run summaries include input hashes and leave output hashes empty;
 completed cleaning summaries include both input and output hashes when files are
 available.
+
+Use `--report-detail full|compact|summary` to control JSON verbosity. `full` is
+the default and preserves all per-file fields, `compact` keeps minimal per-file
+status fields, and `summary` omits per-file entries.

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -16,8 +16,8 @@ privacy risk before implementation.
 
 ### CLI Usability
 - Add optional file output targets for machine-readable command output.
-- Add configurable verbosity levels for per-file report payloads if users need
-  compact reports for very large batches.
+- Add filtering options for report entries if users need only failed files in
+  very large batches.
 
 ### File Format Support
 - Evaluate HEIC/HEIF support with a clear dependency strategy.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -83,6 +83,13 @@ Include SHA-256 checksums in JSON summaries:
 metadata-cleaner delete ./images --summary-file reports/summary.json --checksums
 ```
 
+Control JSON report verbosity for large batches:
+
+```bash
+metadata-cleaner delete ./images --json-summary --report-detail compact
+metadata-cleaner delete ./images --summary-file reports/summary.json --report-detail summary
+```
+
 Preserve source access and modification times on cleaned files:
 
 ```bash

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -43,8 +43,30 @@ def _summary_status(summary: BatchSummary, dry_run: bool) -> str:
     return "partial_failure"
 
 
-def _summary_payload(summary: BatchSummary, dry_run: bool) -> dict:
-    return {
+def _report_files(files: list[dict], report_detail: str) -> list[dict]:
+    if report_detail == "full":
+        return files
+
+    compact_files = []
+    for item in files:
+        compact_item = {
+            "input": item["input"],
+            "status": item["status"],
+        }
+        if "error" in item:
+            compact_item["error"] = item["error"]
+        if "checksums" in item:
+            compact_item["checksums"] = item["checksums"]
+        compact_files.append(compact_item)
+    return compact_files
+
+
+def _summary_payload(
+    summary: BatchSummary,
+    dry_run: bool,
+    report_detail: str = "full",
+) -> dict:
+    payload = {
         "status": _summary_status(summary, dry_run),
         "dry_run": dry_run,
         "total": summary.total,
@@ -53,8 +75,10 @@ def _summary_payload(summary: BatchSummary, dry_run: bool) -> dict:
         "skipped": summary.skipped,
         "would_process": summary.succeeded if dry_run else None,
         "failures": summary.failures,
-        "files": summary.files,
     }
+    if report_detail != "summary":
+        payload["files"] = _report_files(summary.files, report_detail)
+    return payload
 
 
 def _metadata_payload(file_path: str, metadata: Optional[dict], status: str) -> dict:
@@ -88,12 +112,16 @@ def _write_summary_file(
     summary_file: Optional[str],
     summary: BatchSummary,
     dry_run: bool,
+    report_detail: str = "full",
     quiet: bool = False,
 ) -> bool:
     if not summary_file:
         return True
 
-    if _write_json_payload(summary_file, _summary_payload(summary, dry_run)):
+    if _write_json_payload(
+        summary_file,
+        _summary_payload(summary, dry_run, report_detail=report_detail),
+    ):
         return True
 
     if not quiet:
@@ -105,10 +133,11 @@ def _echo_batch_summary(
     summary: BatchSummary,
     dry_run: bool,
     json_summary: bool = False,
+    report_detail: str = "full",
     quiet: bool = False,
 ) -> None:
     if json_summary:
-        _echo_json(_summary_payload(summary, dry_run))
+        _echo_json(_summary_payload(summary, dry_run, report_detail=report_detail))
         return
 
     if quiet:
@@ -288,6 +317,13 @@ def view(ctx, file, json_output):
     help="Include SHA-256 checksums in JSON summaries and summary files.",
 )
 @click.option(
+    "--report-detail",
+    type=click.Choice(["full", "compact", "summary"]),
+    default="full",
+    show_default=True,
+    help="Control detail level for JSON summaries and summary files.",
+)
+@click.option(
     "--preserve-timestamps",
     is_flag=True,
     help="Copy source access and modification times to cleaned outputs.",
@@ -307,6 +343,7 @@ def delete(
     dry_run,
     json_summary,
     checksums,
+    report_detail,
     preserve_timestamps,
     summary_file,
     quiet,
@@ -316,10 +353,21 @@ def delete(
     if not files_to_process:
         summary = BatchSummary(total=0)
         if json_summary:
-            _echo_batch_summary(summary, dry_run, json_summary=True)
+            _echo_batch_summary(
+                summary,
+                dry_run,
+                json_summary=True,
+                report_detail=report_detail,
+            )
         elif not quiet:
             click.echo("No supported files found.")
-        if not _write_summary_file(summary_file, summary, dry_run, quiet):
+        if not _write_summary_file(
+            summary_file,
+            summary,
+            dry_run,
+            report_detail=report_detail,
+            quiet=quiet,
+        ):
             ctx.exit(EXIT_FAILURE)
         ctx.exit(EXIT_USAGE)
 
@@ -344,10 +392,21 @@ def delete(
                 include_checksums=checksums,
             )
             if json_summary:
-                _echo_batch_summary(summary, dry_run, json_summary=True)
+                _echo_batch_summary(
+                    summary,
+                    dry_run,
+                    json_summary=True,
+                    report_detail=report_detail,
+                )
             elif not quiet:
                 click.echo("Dry run complete. No files changed.")
-            if not _write_summary_file(summary_file, summary, dry_run, quiet):
+            if not _write_summary_file(
+                summary_file,
+                summary,
+                dry_run,
+                report_detail=report_detail,
+                quiet=quiet,
+            ):
                 ctx.exit(EXIT_FAILURE)
             ctx.exit(EXIT_SUCCESS)
         elif result:
@@ -360,10 +419,21 @@ def delete(
                 include_checksums=checksums,
             )
             if json_summary:
-                _echo_batch_summary(summary, dry_run, json_summary=True)
+                _echo_batch_summary(
+                    summary,
+                    dry_run,
+                    json_summary=True,
+                    report_detail=report_detail,
+                )
             elif not quiet:
                 click.echo(f"Metadata removed: {result}")
-            if not _write_summary_file(summary_file, summary, dry_run, quiet):
+            if not _write_summary_file(
+                summary_file,
+                summary,
+                dry_run,
+                report_detail=report_detail,
+                quiet=quiet,
+            ):
                 ctx.exit(EXIT_FAILURE)
             ctx.exit(EXIT_SUCCESS)
         else:
@@ -378,10 +448,21 @@ def delete(
                 include_checksums=checksums,
             )
             if json_summary:
-                _echo_batch_summary(summary, dry_run, json_summary=True)
+                _echo_batch_summary(
+                    summary,
+                    dry_run,
+                    json_summary=True,
+                    report_detail=report_detail,
+                )
             elif not quiet:
                 click.echo("Metadata removal failed. Check logs for details.")
-            if not _write_summary_file(summary_file, summary, dry_run, quiet):
+            if not _write_summary_file(
+                summary_file,
+                summary,
+                dry_run,
+                report_detail=report_detail,
+                quiet=quiet,
+            ):
                 ctx.exit(EXIT_FAILURE)
             ctx.exit(EXIT_FAILURE)
 
@@ -441,9 +522,16 @@ def delete(
         summary,
         dry_run,
         json_summary=json_summary,
+        report_detail=report_detail,
         quiet=quiet,
     )
-    if not _write_summary_file(summary_file, summary, dry_run, quiet):
+    if not _write_summary_file(
+        summary_file,
+        summary,
+        dry_run,
+        report_detail=report_detail,
+        quiet=quiet,
+    ):
         ctx.exit(EXIT_FAILURE)
     _exit_for_summary(ctx, summary, dry_run)
 

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -501,6 +501,58 @@ class TestMetadataCleaner(unittest.TestCase):
             warnings = payload["files"][0]["warnings"]
             self.assertTrue(any("re-saves image data" in warning for warning in warnings))
 
+    def test_cli_json_summary_compact_report_detail(self):
+        """Compact JSON reports should omit verbose per-file fields."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Image.new("RGB", (10, 10), color="yellow").save("photo.png", "png")
+
+            result = runner.invoke(
+                cli,
+                [
+                    "delete",
+                    "photo.png",
+                    "--dry-run",
+                    "--json-summary",
+                    "--checksums",
+                    "--report-detail",
+                    "compact",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            item = payload["files"][0]
+            self.assertEqual(item["input"], "photo.png")
+            self.assertEqual(item["status"], "would_process")
+            self.assertIn("checksums", item)
+            self.assertNotIn("output", item)
+            self.assertNotIn("warnings", item)
+
+    def test_cli_json_summary_summary_report_detail(self):
+        """Summary JSON reports should omit per-file entries for large batches."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Image.new("RGB", (10, 10), color="yellow").save("photo.jpg", "jpeg")
+
+            result = runner.invoke(
+                cli,
+                [
+                    "delete",
+                    "photo.jpg",
+                    "--dry-run",
+                    "--json-summary",
+                    "--report-detail",
+                    "summary",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["status"], "success")
+            self.assertEqual(payload["total"], 1)
+            self.assertNotIn("files", payload)
+
     def test_cli_summary_file_with_checksums_for_cleaned_output(self):
         """Checksum reporting should include input and cleaned output hashes."""
         runner = CliRunner()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.10.0"
+version = "3.11.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add metadata-cleaner delete --report-detail full|compact|summary
- keep full as the default to preserve the existing JSON summary shape
- add compact reports with minimal per-file fields and summary reports without per-file entries
- bump package version to v3.11.0 and add curated release notes

## Verification
- poetry check --lock
- pytest: 36 passed, 1 skipped
- flake8 m_c manage.py
- git diff --check
- poetry build: metadata_cleaner-3.11.0
- pip-audit: no known vulnerabilities found; local metadata-cleaner package skipped as expected
- release-note extraction check for v3.11.0