### PR TITLE
feat: add report entry filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Summary reports include per-file status and output paths for audit trails.
 Add `--checksums` to include SHA-256 input/output hashes.
 Add `--preserve-timestamps` when cleaned files should keep source file times.
 Use `--report-detail compact` or `--report-detail summary` for smaller reports.
+Use `--report-filter failed` to list only failed per-file entries.
 Formats that rewrite, re-save, or remux data include per-file warnings in JSON
 summary reports.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v3.12.0
+**Release Date**: 2026-05-10
+
+### Features
+- Added `metadata-cleaner delete --report-filter all|failed` to filter
+  per-file entries in JSON summaries and summary files.
+- `failed` reports keep top-level totals intact while listing only failed
+  per-file entries, which is useful for very large batch runs.
+
 ## v3.11.0
 **Release Date**: 2026-05-10
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -74,3 +74,7 @@ available.
 Use `--report-detail full|compact|summary` to control JSON verbosity. `full` is
 the default and preserves all per-file fields, `compact` keeps minimal per-file
 status fields, and `summary` omits per-file entries.
+
+Use `--report-filter all|failed` to control which per-file entries are included
+when per-file entries are present. `failed` keeps aggregate counts unchanged and
+lists only failed file entries.

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -16,8 +16,8 @@ privacy risk before implementation.
 
 ### CLI Usability
 - Add optional file output targets for machine-readable command output.
-- Add filtering options for report entries if users need only failed files in
-  very large batches.
+- Add additional report filters only if users need more targeted automation
+  views.
 
 ### File Format Support
 - Evaluate HEIC/HEIF support with a clear dependency strategy.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -90,6 +90,12 @@ metadata-cleaner delete ./images --json-summary --report-detail compact
 metadata-cleaner delete ./images --summary-file reports/summary.json --report-detail summary
 ```
 
+List only failed per-file entries while preserving top-level counts:
+
+```bash
+metadata-cleaner delete ./images --json-summary --report-filter failed
+```
+
 Preserve source access and modification times on cleaned files:
 
 ```bash

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -43,7 +43,14 @@ def _summary_status(summary: BatchSummary, dry_run: bool) -> str:
     return "partial_failure"
 
 
-def _report_files(files: list[dict], report_detail: str) -> list[dict]:
+def _report_files(
+    files: list[dict],
+    report_detail: str,
+    report_filter: str = "all",
+) -> list[dict]:
+    if report_filter == "failed":
+        files = [item for item in files if item["status"] == "failed"]
+
     if report_detail == "full":
         return files
 
@@ -65,6 +72,7 @@ def _summary_payload(
     summary: BatchSummary,
     dry_run: bool,
     report_detail: str = "full",
+    report_filter: str = "all",
 ) -> dict:
     payload = {
         "status": _summary_status(summary, dry_run),
@@ -77,7 +85,11 @@ def _summary_payload(
         "failures": summary.failures,
     }
     if report_detail != "summary":
-        payload["files"] = _report_files(summary.files, report_detail)
+        payload["files"] = _report_files(
+            summary.files,
+            report_detail,
+            report_filter=report_filter,
+        )
     return payload
 
 
@@ -113,6 +125,7 @@ def _write_summary_file(
     summary: BatchSummary,
     dry_run: bool,
     report_detail: str = "full",
+    report_filter: str = "all",
     quiet: bool = False,
 ) -> bool:
     if not summary_file:
@@ -120,7 +133,12 @@ def _write_summary_file(
 
     if _write_json_payload(
         summary_file,
-        _summary_payload(summary, dry_run, report_detail=report_detail),
+        _summary_payload(
+            summary,
+            dry_run,
+            report_detail=report_detail,
+            report_filter=report_filter,
+        ),
     ):
         return True
 
@@ -134,10 +152,18 @@ def _echo_batch_summary(
     dry_run: bool,
     json_summary: bool = False,
     report_detail: str = "full",
+    report_filter: str = "all",
     quiet: bool = False,
 ) -> None:
     if json_summary:
-        _echo_json(_summary_payload(summary, dry_run, report_detail=report_detail))
+        _echo_json(
+            _summary_payload(
+                summary,
+                dry_run,
+                report_detail=report_detail,
+                report_filter=report_filter,
+            )
+        )
         return
 
     if quiet:
@@ -324,6 +350,13 @@ def view(ctx, file, json_output):
     help="Control detail level for JSON summaries and summary files.",
 )
 @click.option(
+    "--report-filter",
+    type=click.Choice(["all", "failed"]),
+    default="all",
+    show_default=True,
+    help="Filter per-file entries in JSON summaries and summary files.",
+)
+@click.option(
     "--preserve-timestamps",
     is_flag=True,
     help="Copy source access and modification times to cleaned outputs.",
@@ -344,6 +377,7 @@ def delete(
     json_summary,
     checksums,
     report_detail,
+    report_filter,
     preserve_timestamps,
     summary_file,
     quiet,
@@ -358,6 +392,7 @@ def delete(
                 dry_run,
                 json_summary=True,
                 report_detail=report_detail,
+                report_filter=report_filter,
             )
         elif not quiet:
             click.echo("No supported files found.")
@@ -366,6 +401,7 @@ def delete(
             summary,
             dry_run,
             report_detail=report_detail,
+            report_filter=report_filter,
             quiet=quiet,
         ):
             ctx.exit(EXIT_FAILURE)
@@ -397,6 +433,7 @@ def delete(
                     dry_run,
                     json_summary=True,
                     report_detail=report_detail,
+                    report_filter=report_filter,
                 )
             elif not quiet:
                 click.echo("Dry run complete. No files changed.")
@@ -405,6 +442,7 @@ def delete(
                 summary,
                 dry_run,
                 report_detail=report_detail,
+                report_filter=report_filter,
                 quiet=quiet,
             ):
                 ctx.exit(EXIT_FAILURE)
@@ -424,6 +462,7 @@ def delete(
                     dry_run,
                     json_summary=True,
                     report_detail=report_detail,
+                    report_filter=report_filter,
                 )
             elif not quiet:
                 click.echo(f"Metadata removed: {result}")
@@ -432,6 +471,7 @@ def delete(
                 summary,
                 dry_run,
                 report_detail=report_detail,
+                report_filter=report_filter,
                 quiet=quiet,
             ):
                 ctx.exit(EXIT_FAILURE)
@@ -453,6 +493,7 @@ def delete(
                     dry_run,
                     json_summary=True,
                     report_detail=report_detail,
+                    report_filter=report_filter,
                 )
             elif not quiet:
                 click.echo("Metadata removal failed. Check logs for details.")
@@ -461,6 +502,7 @@ def delete(
                 summary,
                 dry_run,
                 report_detail=report_detail,
+                report_filter=report_filter,
                 quiet=quiet,
             ):
                 ctx.exit(EXIT_FAILURE)
@@ -523,6 +565,7 @@ def delete(
         dry_run,
         json_summary=json_summary,
         report_detail=report_detail,
+        report_filter=report_filter,
         quiet=quiet,
     )
     if not _write_summary_file(
@@ -530,6 +573,7 @@ def delete(
         summary,
         dry_run,
         report_detail=report_detail,
+        report_filter=report_filter,
         quiet=quiet,
     ):
         ctx.exit(EXIT_FAILURE)

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -399,6 +399,80 @@ class TestMetadataCleaner(unittest.TestCase):
             self.assertEqual(failed_item["status"], "failed")
             self.assertEqual(failed_item["error"], "metadata_removal_failed")
 
+    def test_cli_json_summary_failed_report_filter(self):
+        """JSON reports should optionally include only failed per-file entries."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            os.makedirs("inputs", exist_ok=True)
+            Image.new("RGB", (10, 10), color="green").save(
+                os.path.join("inputs", "photo.jpg"),
+                "jpeg",
+            )
+            with open(os.path.join("inputs", "broken.pdf"), "wb") as broken_pdf:
+                broken_pdf.write(b"not a valid pdf")
+
+            result = runner.invoke(
+                cli,
+                [
+                    "delete",
+                    "inputs",
+                    "--output",
+                    "outputs",
+                    "--json-summary",
+                    "--report-filter",
+                    "failed",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 3, result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["total"], 2)
+            self.assertEqual(payload["succeeded"], 1)
+            self.assertEqual(payload["failed"], 1)
+            self.assertEqual(len(payload["files"]), 1)
+            self.assertEqual(payload["files"][0]["input"], os.path.join("inputs", "broken.pdf"))
+            self.assertEqual(payload["files"][0]["status"], "failed")
+
+    def test_cli_summary_file_failed_report_filter_with_compact_detail(self):
+        """Summary files should combine failed filtering with compact detail."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            os.makedirs("inputs", exist_ok=True)
+            Image.new("RGB", (10, 10), color="green").save(
+                os.path.join("inputs", "photo.jpg"),
+                "jpeg",
+            )
+            with open(os.path.join("inputs", "broken.pdf"), "wb") as broken_pdf:
+                broken_pdf.write(b"not a valid pdf")
+
+            result = runner.invoke(
+                cli,
+                [
+                    "delete",
+                    "inputs",
+                    "--output",
+                    "outputs",
+                    "--summary-file",
+                    "summary.json",
+                    "--report-detail",
+                    "compact",
+                    "--report-filter",
+                    "failed",
+                    "--quiet",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 3, result.output)
+            with open("summary.json") as summary_file:
+                payload = json.load(summary_file)
+            self.assertEqual(payload["total"], 2)
+            self.assertEqual(len(payload["files"]), 1)
+            failed_item = payload["files"][0]
+            self.assertEqual(failed_item["input"], os.path.join("inputs", "broken.pdf"))
+            self.assertEqual(failed_item["status"], "failed")
+            self.assertIn("error", failed_item)
+            self.assertNotIn("output", failed_item)
+
     def test_cli_summary_file_for_batch(self):
         """Batch delete should write machine-readable summaries to a file."""
         runner = CliRunner()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.11.0"
+version = "3.12.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add metadata-cleaner delete --report-filter all|failed
- preserve top-level totals while filtering per-file report entries
- support failed-only reports with full and compact detail modes
- bump package version to v3.12.0 and add curated release notes

## Verification
- poetry check --lock
- pytest: 38 passed, 1 skipped
- flake8 m_c manage.py
- git diff --check
- poetry build: metadata_cleaner-3.12.0
- pip-audit: no known vulnerabilities found; local metadata-cleaner package skipped as expected
- release-note extraction check for v3.12.0