### PR TITLE
feat: add ODT metadata cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ in-place.
 ## Supported Files
 
 - Images: JPG, JPEG, PNG, TIFF, WEBP, AVIF
-- Documents: PDF, DOCX, TXT
+- Documents: PDF, DOCX, ODT, TXT
 - Audio: MP3, WAV, FLAC, OGG, AAC, M4A, WMA
 - Video: MP4, MKV, MOV, AVI, WEBM, FLV
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## v3.13.0
+**Release Date**: 2026-05-10
+
+### Features
+- Added ODT metadata viewing and cleanup using the standard OpenDocument
+  `meta.xml` package metadata.
+- ODT cleanup clears package metadata while preserving the rest of the
+  document package contents.
+
+### Maintenance
+- Added generated ODT fixture coverage for metadata extraction, cleanup, and
+  CLI processing warnings.
+
 ## v3.12.0
 **Release Date**: 2026-05-10
 

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -21,7 +21,7 @@ privacy risk before implementation.
 
 ### File Format Support
 - Evaluate HEIC/HEIF support with a clear dependency strategy.
-- Evaluate ODT and EPUB metadata cleanup.
+- Evaluate EPUB metadata cleanup.
 - Expand audio/video tests before expanding advertised format support.
 
 ## Medium Term

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -154,7 +154,7 @@ metadata-cleaner edit song.mp3 --changes '{"artist": "Unknown"}'
 ## Supported Formats
 
 - Images: JPEG, PNG, TIFF, WebP, AVIF
-- Documents: PDF, DOCX, TXT
+- Documents: PDF, DOCX, ODT, TXT
 - Audio: MP3, WAV, FLAC, OGG, AAC, M4A, WMA
 - Video: MP4, MKV, MOV, AVI, WebM, FLV
 

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -248,6 +248,10 @@ def _processing_warnings(file_path: str) -> list[str]:
             "DOCX metadata removal rewrites the document package while "
             "preserving content."
         ],
+        ".odt": [
+            "ODT metadata removal rewrites the document package while "
+            "preserving content."
+        ],
         ".mp3": ["Audio metadata removal rewrites tags on a copied audio file."],
         ".wav": ["Audio metadata removal rewrites tags on a copied audio file."],
         ".flac": ["Audio metadata removal rewrites tags on a copied audio file."],

--- a/m_c/config/settings.py
+++ b/m_c/config/settings.py
@@ -31,7 +31,7 @@ LOG_LEVEL = get_env_variable("METADATA_CLEANER_LOG_LEVEL", "INFO").upper()
 # Supported file formats
 SUPPORTED_FORMATS = {
     "images": {".jpg", ".jpeg", ".png", ".tiff", ".webp"},
-    "documents": {".pdf", ".docx", ".txt"},
+    "documents": {".pdf", ".docx", ".odt", ".txt"},
     "audio": {".mp3", ".wav", ".flac"},
     "videos": {".mp4", ".mkv", ".avi"},
 }

--- a/m_c/core/file_utils.py
+++ b/m_c/core/file_utils.py
@@ -69,6 +69,7 @@ ALL_SUPPORTED_EXTENSIONS = {
     # Documents
     ".pdf",
     ".docx",
+    ".odt",
     ".txt",
     # Video/Audio
     ".mp4",

--- a/m_c/handlers/document_handler.py
+++ b/m_c/handlers/document_handler.py
@@ -2,6 +2,8 @@ from datetime import datetime
 import os
 import shutil
 from typing import Optional, Dict, Any
+import xml.etree.ElementTree as ET
+import zipfile
 import pikepdf
 import pypdf
 
@@ -19,7 +21,12 @@ class DocumentHandler(BaseHandler):
     Handles metadata extraction, removal, and editing for document files.
     """
 
-    SUPPORTED_FORMATS = {"pdf", "docx", "txt"}
+    SUPPORTED_FORMATS = {"pdf", "docx", "odt", "txt"}
+    ODT_NAMESPACES = {
+        "office": "urn:oasis:names:tc:opendocument:xmlns:office:1.0",
+        "dc": "http://purl.org/dc/elements/1.1/",
+        "meta": "urn:oasis:names:tc:opendocument:xmlns:meta:1.0",
+    }
 
     def extract_metadata(self, file_path: str) -> Optional[Dict[str, Any]]:
         """Extract metadata from a document file."""
@@ -32,6 +39,8 @@ class DocumentHandler(BaseHandler):
                 return self._extract_metadata_pdf(file_path)
             elif ext == ".docx":
                 return self._extract_metadata_docx(file_path)
+            elif ext == ".odt":
+                return self._extract_metadata_odt(file_path)
             elif ext == ".txt":
                 return {}
         except Exception as e:
@@ -86,6 +95,8 @@ class DocumentHandler(BaseHandler):
                 return self._remove_metadata_pdf(file_path, output_path)
             elif ext == ".docx":
                 return self._remove_metadata_docx(file_path, output_path)
+            elif ext == ".odt":
+                return self._remove_metadata_odt(file_path, output_path)
             elif ext == ".txt":
                 shutil.copy2(file_path, output_path)
                 return output_path
@@ -147,6 +158,65 @@ class DocumentHandler(BaseHandler):
             return output_path
         except Exception as e:
             logger.error(f"Failed to remove metadata from DOCX: {e}", exc_info=True)
+            return None
+
+    def _extract_metadata_odt(self, file_path: str) -> Optional[Dict[str, Any]]:
+        """Extract common OpenDocument metadata from meta.xml."""
+        try:
+            with zipfile.ZipFile(file_path, "r") as archive:
+                try:
+                    metadata_xml = archive.read("meta.xml")
+                except KeyError:
+                    return {}
+
+            root = ET.fromstring(metadata_xml)
+            metadata = {}
+            for element in root.iter():
+                if element is root or list(element):
+                    continue
+                text = (element.text or "").strip()
+                if text:
+                    name = element.tag.rsplit("}", 1)[-1]
+                    metadata[name] = text
+            return metadata
+        except Exception as e:
+            logger.error(f"ODT metadata extraction failed for {file_path}: {e}")
+            return None
+
+    def _empty_odt_metadata_xml(self) -> bytes:
+        """Return an empty OpenDocument metadata XML document."""
+        for prefix, uri in self.ODT_NAMESPACES.items():
+            ET.register_namespace(prefix, uri)
+
+        office_uri = self.ODT_NAMESPACES["office"]
+        root = ET.Element(f"{{{office_uri}}}document-meta")
+        ET.SubElement(root, f"{{{office_uri}}}meta")
+        return ET.tostring(root, encoding="utf-8", xml_declaration=True)
+
+    def _remove_metadata_odt(self, file_path: str, output_path: str) -> Optional[str]:
+        """Clear OpenDocument metadata while preserving package contents."""
+        try:
+            empty_metadata = self._empty_odt_metadata_xml()
+            wrote_metadata = False
+
+            with zipfile.ZipFile(file_path, "r") as source:
+                with zipfile.ZipFile(output_path, "w") as target:
+                    for info in source.infolist():
+                        data = source.read(info.filename)
+                        if info.filename == "meta.xml":
+                            data = empty_metadata
+                            wrote_metadata = True
+                        target.writestr(info, data)
+
+                    if not wrote_metadata:
+                        target.writestr("meta.xml", empty_metadata)
+
+            logger.info(f"ODT metadata removed: {output_path}")
+            return output_path
+        except Exception as e:
+            logger.error(f"Failed to remove metadata from ODT: {e}", exc_info=True)
+            if os.path.exists(output_path):
+                os.remove(output_path)
             return None
 
 

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import unittest
 import wave
+import zipfile
 from logging.handlers import RotatingFileHandler
 from click.testing import CliRunner
 import docx
@@ -36,6 +37,35 @@ class TestMetadataCleaner(unittest.TestCase):
         audio.tags.add(TIT2(encoding=3, text="Fixture Title"))
         audio.tags.add(TPE1(encoding=3, text="Fixture Artist"))
         audio.save()
+
+    @staticmethod
+    def _write_odt(file_path):
+        meta_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<office:document-meta
+    xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0">
+  <office:meta>
+    <dc:title>ODT Fixture Title</dc:title>
+    <meta:initial-creator>ODT Fixture Author</meta:initial-creator>
+    <dc:description>ODT Fixture Description</dc:description>
+  </office:meta>
+</office:document-meta>
+"""
+        content_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content
+    xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0">
+  <office:body>Metadata Cleaner ODT body</office:body>
+</office:document-content>
+"""
+        with zipfile.ZipFile(file_path, "w") as archive:
+            archive.writestr(
+                "mimetype",
+                "application/vnd.oasis.opendocument.text",
+                compress_type=zipfile.ZIP_STORED,
+            )
+            archive.writestr("content.xml", content_xml)
+            archive.writestr("meta.xml", meta_xml)
 
     @classmethod
     def setUpClass(cls):
@@ -284,6 +314,31 @@ class TestMetadataCleaner(unittest.TestCase):
         self.assertEqual(cleaned_props.title, "")
         self.assertEqual(cleaned_props.created.year, 1980)
         self.assertEqual(cleaned_props.modified.year, 1980)
+
+    def test_odt_metadata_removal_clears_meta_xml_and_preserves_content(self):
+        """ODT cleaning should clear package metadata while preserving content."""
+        source_odt = os.path.join(self.test_dir, "sample.odt")
+        cleaned_odt = os.path.join(self.cleaned_dir, "cleaned_sample.odt")
+        self._write_odt(source_odt)
+
+        metadata = self.processor.view_metadata(source_odt)
+        self.assertEqual(metadata["title"], "ODT Fixture Title")
+        self.assertEqual(metadata["initial-creator"], "ODT Fixture Author")
+        self.assertEqual(metadata["description"], "ODT Fixture Description")
+
+        output_file = self.processor.delete_metadata(source_odt, cleaned_odt)
+
+        self.assertEqual(output_file, cleaned_odt)
+        self.assertTrue(os.path.exists(source_odt))
+        self.assertTrue(os.path.exists(cleaned_odt))
+        self.assertEqual(self.processor.view_metadata(cleaned_odt), {})
+
+        with zipfile.ZipFile(cleaned_odt, "r") as cleaned_archive:
+            self.assertIn("content.xml", cleaned_archive.namelist())
+            self.assertIn(
+                b"Metadata Cleaner ODT body",
+                cleaned_archive.read("content.xml"),
+            )
 
     def test_in_place_output_path_is_rejected(self):
         """Handlers should reject an output path that equals the input path."""
@@ -574,6 +629,24 @@ class TestMetadataCleaner(unittest.TestCase):
             payload = json.loads(result.output)
             warnings = payload["files"][0]["warnings"]
             self.assertTrue(any("re-saves image data" in warning for warning in warnings))
+
+    def test_cli_json_summary_includes_odt_processing_warning(self):
+        """ODT dry-run reports should describe package rewrite behavior."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            self._write_odt("document.odt")
+
+            result = runner.invoke(
+                cli,
+                ["delete", "document.odt", "--dry-run", "--json-summary"],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            warnings = payload["files"][0]["warnings"]
+            self.assertTrue(
+                any("ODT metadata removal rewrites" in warning for warning in warnings)
+            )
 
     def test_cli_json_summary_compact_report_detail(self):
         """Compact JSON reports should omit verbose per-file fields."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.12.0"
+version = "3.13.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add ODT metadata viewing and cleanup via OpenDocument meta.xml
- include ODT in supported document formats and CLI processing warnings
- add generated ODT fixture coverage plus v3.13.0 release notes

## Verification
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m pytest
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m flake8 m_c manage.py
- git diff --check
- env PYTHONPATH=/tmp/metadata-cleaner-poetry POETRY_CACHE_DIR=/tmp/metadata-cleaner-poetry-cache python3 -m poetry check --lock
- env PYTHONPATH=/tmp/metadata-cleaner-poetry POETRY_CACHE_DIR=/tmp/metadata-cleaner-poetry-cache python3 -m poetry build
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m pip_audit --cache-dir /tmp/metadata-cleaner-pip-audit-cache-2 --path /tmp/metadata-cleaner-test-deps