### PR TITLE
feat: add EPUB metadata cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ in-place.
 ## Supported Files
 
 - Images: JPG, JPEG, PNG, TIFF, WEBP, AVIF
-- Documents: PDF, DOCX, ODT, TXT
+- Documents: PDF, DOCX, EPUB, ODT, TXT
 - Audio: MP3, WAV, FLAC, OGG, AAC, M4A, WMA
 - Video: MP4, MKV, MOV, AVI, WEBM, FLV
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## v3.14.0
+**Release Date**: 2026-05-10
+
+### Features
+- Added EPUB metadata viewing and cleanup through the package OPF metadata
+  document referenced by `META-INF/container.xml`.
+- EPUB cleanup neutralizes identifying package metadata while preserving
+  required EPUB fields and book contents.
+
+### Maintenance
+- Added generated EPUB fixture coverage for metadata extraction, cleanup, and
+  CLI processing warnings.
+
 ## v3.13.0
 **Release Date**: 2026-05-10
 

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -21,7 +21,6 @@ privacy risk before implementation.
 
 ### File Format Support
 - Evaluate HEIC/HEIF support with a clear dependency strategy.
-- Evaluate EPUB metadata cleanup.
 - Expand audio/video tests before expanding advertised format support.
 
 ## Medium Term

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -154,7 +154,7 @@ metadata-cleaner edit song.mp3 --changes '{"artist": "Unknown"}'
 ## Supported Formats
 
 - Images: JPEG, PNG, TIFF, WebP, AVIF
-- Documents: PDF, DOCX, ODT, TXT
+- Documents: PDF, DOCX, EPUB, ODT, TXT
 - Audio: MP3, WAV, FLAC, OGG, AAC, M4A, WMA
 - Video: MP4, MKV, MOV, AVI, WebM, FLV
 

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -248,6 +248,10 @@ def _processing_warnings(file_path: str) -> list[str]:
             "DOCX metadata removal rewrites the document package while "
             "preserving content."
         ],
+        ".epub": [
+            "EPUB metadata removal rewrites the book package while preserving "
+            "content."
+        ],
         ".odt": [
             "ODT metadata removal rewrites the document package while "
             "preserving content."

--- a/m_c/config/settings.py
+++ b/m_c/config/settings.py
@@ -31,7 +31,7 @@ LOG_LEVEL = get_env_variable("METADATA_CLEANER_LOG_LEVEL", "INFO").upper()
 # Supported file formats
 SUPPORTED_FORMATS = {
     "images": {".jpg", ".jpeg", ".png", ".tiff", ".webp"},
-    "documents": {".pdf", ".docx", ".odt", ".txt"},
+    "documents": {".pdf", ".docx", ".epub", ".odt", ".txt"},
     "audio": {".mp3", ".wav", ".flac"},
     "videos": {".mp4", ".mkv", ".avi"},
 }

--- a/m_c/core/file_utils.py
+++ b/m_c/core/file_utils.py
@@ -69,6 +69,7 @@ ALL_SUPPORTED_EXTENSIONS = {
     # Documents
     ".pdf",
     ".docx",
+    ".epub",
     ".odt",
     ".txt",
     # Video/Audio

--- a/m_c/handlers/document_handler.py
+++ b/m_c/handlers/document_handler.py
@@ -21,11 +21,16 @@ class DocumentHandler(BaseHandler):
     Handles metadata extraction, removal, and editing for document files.
     """
 
-    SUPPORTED_FORMATS = {"pdf", "docx", "odt", "txt"}
+    SUPPORTED_FORMATS = {"pdf", "docx", "epub", "odt", "txt"}
     ODT_NAMESPACES = {
         "office": "urn:oasis:names:tc:opendocument:xmlns:office:1.0",
         "dc": "http://purl.org/dc/elements/1.1/",
         "meta": "urn:oasis:names:tc:opendocument:xmlns:meta:1.0",
+    }
+    EPUB_NAMESPACES = {
+        "container": "urn:oasis:names:tc:opendocument:xmlns:container",
+        "dc": "http://purl.org/dc/elements/1.1/",
+        "opf": "http://www.idpf.org/2007/opf",
     }
 
     def extract_metadata(self, file_path: str) -> Optional[Dict[str, Any]]:
@@ -39,6 +44,8 @@ class DocumentHandler(BaseHandler):
                 return self._extract_metadata_pdf(file_path)
             elif ext == ".docx":
                 return self._extract_metadata_docx(file_path)
+            elif ext == ".epub":
+                return self._extract_metadata_epub(file_path)
             elif ext == ".odt":
                 return self._extract_metadata_odt(file_path)
             elif ext == ".txt":
@@ -95,6 +102,8 @@ class DocumentHandler(BaseHandler):
                 return self._remove_metadata_pdf(file_path, output_path)
             elif ext == ".docx":
                 return self._remove_metadata_docx(file_path, output_path)
+            elif ext == ".epub":
+                return self._remove_metadata_epub(file_path, output_path)
             elif ext == ".odt":
                 return self._remove_metadata_odt(file_path, output_path)
             elif ext == ".txt":
@@ -160,6 +169,17 @@ class DocumentHandler(BaseHandler):
             logger.error(f"Failed to remove metadata from DOCX: {e}", exc_info=True)
             return None
 
+    def _xml_local_name(self, tag: str) -> str:
+        """Return an XML tag name without its namespace."""
+        return tag.rsplit("}", 1)[-1]
+
+    def _find_child_by_local_name(self, element: ET.Element, name: str):
+        """Find the first direct child with a matching local XML name."""
+        for child in element:
+            if self._xml_local_name(child.tag) == name:
+                return child
+        return None
+
     def _extract_metadata_odt(self, file_path: str) -> Optional[Dict[str, Any]]:
         """Extract common OpenDocument metadata from meta.xml."""
         try:
@@ -176,7 +196,7 @@ class DocumentHandler(BaseHandler):
                     continue
                 text = (element.text or "").strip()
                 if text:
-                    name = element.tag.rsplit("}", 1)[-1]
+                    name = self._xml_local_name(element.tag)
                     metadata[name] = text
             return metadata
         except Exception as e:
@@ -215,6 +235,110 @@ class DocumentHandler(BaseHandler):
             return output_path
         except Exception as e:
             logger.error(f"Failed to remove metadata from ODT: {e}", exc_info=True)
+            if os.path.exists(output_path):
+                os.remove(output_path)
+            return None
+
+    def _epub_package_path(self, archive: zipfile.ZipFile) -> str:
+        """Return the package document path from an EPUB archive."""
+        try:
+            container_xml = archive.read("META-INF/container.xml")
+        except KeyError:
+            for name in archive.namelist():
+                if name.lower().endswith(".opf"):
+                    return name
+            raise ValueError("EPUB package document not found")
+
+        root = ET.fromstring(container_xml)
+        container_uri = self.EPUB_NAMESPACES["container"]
+        rootfiles = root.findall(f".//{{{container_uri}}}rootfile")
+        for rootfile in rootfiles:
+            package_path = rootfile.attrib.get("full-path")
+            if package_path:
+                return package_path
+        raise ValueError("EPUB container does not reference a package document")
+
+    def _extract_metadata_epub(self, file_path: str) -> Optional[Dict[str, Any]]:
+        """Extract EPUB package metadata from the OPF document."""
+        try:
+            with zipfile.ZipFile(file_path, "r") as archive:
+                package_path = self._epub_package_path(archive)
+                package_xml = archive.read(package_path)
+
+            root = ET.fromstring(package_xml)
+            metadata_element = self._find_child_by_local_name(root, "metadata")
+            if metadata_element is None:
+                return {}
+
+            metadata = {}
+            for element in metadata_element:
+                if list(element):
+                    continue
+                text = (element.text or "").strip()
+                if not text:
+                    continue
+                name = self._xml_local_name(element.tag)
+                if name == "meta":
+                    name = (
+                        element.attrib.get("property")
+                        or element.attrib.get("name")
+                        or "meta"
+                    )
+                metadata[name] = text
+            return metadata
+        except Exception as e:
+            logger.error(f"EPUB metadata extraction failed for {file_path}: {e}")
+            return None
+
+    def _neutralize_epub_package_metadata(self, package_xml: bytes) -> bytes:
+        """Replace EPUB metadata with neutral required package values."""
+        for prefix, uri in self.EPUB_NAMESPACES.items():
+            if prefix != "container":
+                ET.register_namespace(prefix, uri)
+
+        root = ET.fromstring(package_xml)
+        metadata_element = self._find_child_by_local_name(root, "metadata")
+        if metadata_element is None:
+            opf_uri = self.EPUB_NAMESPACES["opf"]
+            metadata_element = ET.Element(f"{{{opf_uri}}}metadata")
+            root.insert(0, metadata_element)
+
+        metadata_element.clear()
+        dc_uri = self.EPUB_NAMESPACES["dc"]
+        identifier = ET.SubElement(
+            metadata_element,
+            f"{{{dc_uri}}}identifier",
+            {"id": "metadata-cleaner-id"},
+        )
+        identifier.text = "urn:uuid:00000000-0000-0000-0000-000000000000"
+        title = ET.SubElement(metadata_element, f"{{{dc_uri}}}title")
+        title.text = "Untitled"
+        language = ET.SubElement(metadata_element, f"{{{dc_uri}}}language")
+        language.text = "und"
+        root.set("unique-identifier", "metadata-cleaner-id")
+        return ET.tostring(root, encoding="utf-8", xml_declaration=True)
+
+    def _remove_metadata_epub(self, file_path: str, output_path: str) -> Optional[str]:
+        """Neutralize EPUB package metadata while preserving book contents."""
+        try:
+            with zipfile.ZipFile(file_path, "r") as source:
+                package_path = self._epub_package_path(source)
+                package_xml = source.read(package_path)
+                cleaned_package_xml = self._neutralize_epub_package_metadata(
+                    package_xml
+                )
+
+                with zipfile.ZipFile(output_path, "w") as target:
+                    for info in source.infolist():
+                        data = source.read(info.filename)
+                        if info.filename == package_path:
+                            data = cleaned_package_xml
+                        target.writestr(info, data)
+
+            logger.info(f"EPUB metadata removed: {output_path}")
+            return output_path
+        except Exception as e:
+            logger.error(f"Failed to remove metadata from EPUB: {e}", exc_info=True)
             if os.path.exists(output_path):
                 os.remove(output_path)
             return None

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -67,6 +67,51 @@ class TestMetadataCleaner(unittest.TestCase):
             archive.writestr("content.xml", content_xml)
             archive.writestr("meta.xml", meta_xml)
 
+    @staticmethod
+    def _write_epub(file_path):
+        container_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0"
+    xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OPS/package.opf"
+        media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+"""
+        package_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf"
+    unique-identifier="bookid" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="bookid">urn:uuid:fixture-book-id</dc:identifier>
+    <dc:title>EPUB Fixture Title</dc:title>
+    <dc:creator>EPUB Fixture Author</dc:creator>
+    <dc:description>EPUB Fixture Description</dc:description>
+    <meta property="dcterms:modified">2026-05-10T00:00:00Z</meta>
+  </metadata>
+  <manifest>
+    <item id="chapter" href="chapter.xhtml"
+        media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="chapter"/>
+  </spine>
+</package>
+"""
+        chapter_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body><p>Metadata Cleaner EPUB body</p></body>
+</html>
+"""
+        with zipfile.ZipFile(file_path, "w") as archive:
+            archive.writestr(
+                "mimetype",
+                "application/epub+zip",
+                compress_type=zipfile.ZIP_STORED,
+            )
+            archive.writestr("META-INF/container.xml", container_xml)
+            archive.writestr("OPS/package.opf", package_xml)
+            archive.writestr("OPS/chapter.xhtml", chapter_xml)
+
     @classmethod
     def setUpClass(cls):
         """Setup test environment before all tests."""
@@ -338,6 +383,41 @@ class TestMetadataCleaner(unittest.TestCase):
             self.assertIn(
                 b"Metadata Cleaner ODT body",
                 cleaned_archive.read("content.xml"),
+            )
+
+    def test_epub_metadata_removal_neutralizes_package_metadata(self):
+        """EPUB cleaning should neutralize package metadata and preserve content."""
+        source_epub = os.path.join(self.test_dir, "sample.epub")
+        cleaned_epub = os.path.join(self.cleaned_dir, "cleaned_sample.epub")
+        self._write_epub(source_epub)
+
+        metadata = self.processor.view_metadata(source_epub)
+        self.assertEqual(metadata["title"], "EPUB Fixture Title")
+        self.assertEqual(metadata["creator"], "EPUB Fixture Author")
+        self.assertEqual(metadata["description"], "EPUB Fixture Description")
+        self.assertEqual(metadata["dcterms:modified"], "2026-05-10T00:00:00Z")
+
+        output_file = self.processor.delete_metadata(source_epub, cleaned_epub)
+
+        self.assertEqual(output_file, cleaned_epub)
+        self.assertTrue(os.path.exists(source_epub))
+        self.assertTrue(os.path.exists(cleaned_epub))
+        cleaned_metadata = self.processor.view_metadata(cleaned_epub)
+        self.assertEqual(cleaned_metadata["title"], "Untitled")
+        self.assertEqual(cleaned_metadata["language"], "und")
+        self.assertEqual(
+            cleaned_metadata["identifier"],
+            "urn:uuid:00000000-0000-0000-0000-000000000000",
+        )
+        self.assertNotIn("creator", cleaned_metadata)
+        self.assertNotIn("description", cleaned_metadata)
+        self.assertNotIn("dcterms:modified", cleaned_metadata)
+
+        with zipfile.ZipFile(cleaned_epub, "r") as cleaned_archive:
+            self.assertIn("OPS/chapter.xhtml", cleaned_archive.namelist())
+            self.assertIn(
+                b"Metadata Cleaner EPUB body",
+                cleaned_archive.read("OPS/chapter.xhtml"),
             )
 
     def test_in_place_output_path_is_rejected(self):
@@ -646,6 +726,24 @@ class TestMetadataCleaner(unittest.TestCase):
             warnings = payload["files"][0]["warnings"]
             self.assertTrue(
                 any("ODT metadata removal rewrites" in warning for warning in warnings)
+            )
+
+    def test_cli_json_summary_includes_epub_processing_warning(self):
+        """EPUB dry-run reports should describe package rewrite behavior."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            self._write_epub("book.epub")
+
+            result = runner.invoke(
+                cli,
+                ["delete", "book.epub", "--dry-run", "--json-summary"],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            warnings = payload["files"][0]["warnings"]
+            self.assertTrue(
+                any("EPUB metadata removal rewrites" in warning for warning in warnings)
             )
 
     def test_cli_json_summary_compact_report_detail(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.13.0"
+version = "3.14.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add EPUB metadata viewing and cleanup through the OPF package metadata document
- neutralize identifying EPUB metadata while preserving required package fields and book contents
- include EPUB in supported document formats, CLI warnings, generated fixture tests, and v3.14.0 release notes

## Verification
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m pytest
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m flake8 m_c manage.py
- git diff --check
- env PYTHONPATH=/tmp/metadata-cleaner-poetry POETRY_CACHE_DIR=/tmp/metadata-cleaner-poetry-cache python3 -m poetry check --lock
- env PYTHONPATH=/tmp/metadata-cleaner-poetry POETRY_CACHE_DIR=/tmp/metadata-cleaner-poetry-cache python3 -m poetry build
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m pip_audit --cache-dir /tmp/metadata-cleaner-pip-audit-cache-2 --path /tmp/metadata-cleaner-test-deps