### PR TITLE
feat: add HEIC and HEIF ExifTool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ in-place.
 
 ## Supported Files
 
-- Images: JPG, JPEG, PNG, TIFF, WEBP, AVIF
+- Images: JPG, JPEG, PNG, TIFF, WEBP, AVIF, HEIC, HEIF
 - Documents: PDF, DOCX, EPUB, ODT, TXT
 - Audio: MP3, WAV, FLAC, OGG, AAC, M4A, WMA
 - Video: MP4, MKV, MOV, AVI, WEBM, FLV

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,19 @@
 # Release Notes
 
+## v3.15.0
+**Release Date**: 2026-05-10
+
+### Features
+- Added HEIC and HEIF file discovery plus ExifTool-backed metadata cleanup.
+- HEIC/HEIF dry-run and JSON reports now include processing warnings that
+  explain the external-tool dependency.
+
+### Maintenance
+- Documented the HEIC/HEIF support strategy without adding a new image codec
+  dependency.
+- Added tests for HEIC/HEIF recognition, HEIC cleanup routing, and CLI warning
+  output.
+
 ## v3.14.0
 **Release Date**: 2026-05-10
 

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -20,7 +20,6 @@ privacy risk before implementation.
   views.
 
 ### File Format Support
-- Evaluate HEIC/HEIF support with a clear dependency strategy.
 - Expand audio/video tests before expanding advertised format support.
 
 ## Medium Term

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -153,7 +153,7 @@ metadata-cleaner edit song.mp3 --changes '{"artist": "Unknown"}'
 
 ## Supported Formats
 
-- Images: JPEG, PNG, TIFF, WebP, AVIF
+- Images: JPEG, PNG, TIFF, WebP, AVIF, HEIC, HEIF
 - Documents: PDF, DOCX, EPUB, ODT, TXT
 - Audio: MP3, WAV, FLAC, OGG, AAC, M4A, WMA
 - Video: MP4, MKV, MOV, AVI, WebM, FLV

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -248,6 +248,14 @@ def _processing_warnings(file_path: str) -> list[str]:
             "DOCX metadata removal rewrites the document package while "
             "preserving content."
         ],
+        ".heic": [
+            "HEIC metadata removal requires ExifTool and rewrites metadata on "
+            "a copied file."
+        ],
+        ".heif": [
+            "HEIF metadata removal requires ExifTool and rewrites metadata on "
+            "a copied file."
+        ],
         ".epub": [
             "EPUB metadata removal rewrites the book package while preserving "
             "content."

--- a/m_c/config/settings.py
+++ b/m_c/config/settings.py
@@ -30,7 +30,7 @@ LOG_LEVEL = get_env_variable("METADATA_CLEANER_LOG_LEVEL", "INFO").upper()
 
 # Supported file formats
 SUPPORTED_FORMATS = {
-    "images": {".jpg", ".jpeg", ".png", ".tiff", ".webp"},
+    "images": {".jpg", ".jpeg", ".png", ".tiff", ".webp", ".avif", ".heic", ".heif"},
     "documents": {".pdf", ".docx", ".epub", ".odt", ".txt"},
     "audio": {".mp3", ".wav", ".flac"},
     "videos": {".mp4", ".mkv", ".avi"},

--- a/m_c/core/file_utils.py
+++ b/m_c/core/file_utils.py
@@ -66,6 +66,8 @@ ALL_SUPPORTED_EXTENSIONS = {
     ".tiff",
     ".webp",
     ".avif",
+    ".heic",
+    ".heif",
     # Documents
     ".pdf",
     ".docx",

--- a/m_c/handlers/image_handler.py
+++ b/m_c/handlers/image_handler.py
@@ -17,7 +17,15 @@ class ImageHandler(BaseHandler):
     Uses ExifTool and Piexif.
     """
 
-    SUPPORTED_FORMATS = {"jpg", "jpeg", "png", "tiff", "webp", "avif"}
+    EXIFTOOL_ONLY_FORMATS = {"avif", "heic", "heif"}
+    SUPPORTED_FORMATS = {
+        "jpg",
+        "jpeg",
+        "png",
+        "tiff",
+        "webp",
+        *EXIFTOOL_ONLY_FORMATS,
+    }
 
     def extract_metadata(self, file_path: str) -> Optional[Dict[str, Any]]:
         """Extract metadata with fallback methods."""
@@ -46,8 +54,8 @@ class ImageHandler(BaseHandler):
             logger.debug(f"Processing image: {file_path}")
             ext = os.path.splitext(file_path)[1].lower()
 
-            if ext == ".avif":
-                logger.info(f"Using ExifTool for AVIF: {file_path}")
+            if ext.strip(".") in self.EXIFTOOL_ONLY_FORMATS:
+                logger.info(f"Using ExifTool for {ext.upper().strip('.')}: {file_path}")
                 return self._remove_metadata_exiftool(file_path, output_path)
 
             if ext in {".jpg", ".jpeg", ".webp", ".tiff", ".tif"}:

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -7,6 +7,7 @@ import unittest
 import wave
 import zipfile
 from logging.handlers import RotatingFileHandler
+from unittest.mock import patch
 from click.testing import CliRunner
 import docx
 from mutagen import File as MutagenFile
@@ -293,6 +294,39 @@ class TestMetadataCleaner(unittest.TestCase):
             f.write(b"dummy binary data")
 
         self.assertTrue(image_handler.is_supported(avif_path))
+
+    def test_heic_heif_recognition(self):
+        """Verify HEIC and HEIF files are recognized by ImageHandler."""
+        from m_c.handlers.image_handler import image_handler
+
+        self.assertIn("heic", image_handler.SUPPORTED_FORMATS)
+        self.assertIn("heif", image_handler.SUPPORTED_FORMATS)
+
+        for extension in ("heic", "heif"):
+            image_path = os.path.join(self.test_dir, f"test.{extension}")
+            with open(image_path, "wb") as image_file:
+                image_file.write(b"dummy binary data")
+
+            self.assertTrue(image_handler.is_supported(image_path))
+
+    def test_heic_metadata_removal_uses_exiftool_path(self):
+        """HEIC cleanup should use the ExifTool-backed image path."""
+        from m_c.handlers.image_handler import image_handler
+
+        source_heic = os.path.join(self.test_dir, "source.heic")
+        cleaned_heic = os.path.join(self.cleaned_dir, "source_cleaned.heic")
+        with open(source_heic, "wb") as image_file:
+            image_file.write(b"dummy binary data")
+
+        with patch.object(
+            image_handler,
+            "_remove_metadata_exiftool",
+            return_value=cleaned_heic,
+        ) as remove_metadata:
+            result = image_handler.remove_metadata(source_heic, cleaned_heic)
+
+        self.assertEqual(result, cleaned_heic)
+        remove_metadata.assert_called_once_with(source_heic, cleaned_heic)
 
     def test_dry_run_mechanism(self):
         """Test dry run flag does not modify files."""
@@ -744,6 +778,26 @@ class TestMetadataCleaner(unittest.TestCase):
             warnings = payload["files"][0]["warnings"]
             self.assertTrue(
                 any("EPUB metadata removal rewrites" in warning for warning in warnings)
+            )
+
+    def test_cli_json_summary_includes_heic_processing_warning(self):
+        """HEIC dry-run reports should describe the ExifTool-backed path."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("photo.heic", "wb") as image_file:
+                image_file.write(b"dummy binary data")
+
+            result = runner.invoke(
+                cli,
+                ["delete", "photo.heic", "--dry-run", "--json-summary"],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            warnings = payload["files"][0]["warnings"]
+            self.assertTrue(
+                any("HEIC metadata removal requires ExifTool" in warning
+                    for warning in warnings)
             )
 
     def test_cli_json_summary_compact_report_detail(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.14.0"
+version = "3.15.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add HEIC and HEIF file discovery and routing through the ExifTool-backed image cleanup path
- include HEIC/HEIF in supported image docs and configuration without adding a new image codec dependency
- add dry-run JSON warnings plus tests for recognition, cleanup routing, and report output

## Verification
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m pytest
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m flake8 m_c manage.py
- git diff --check
- env PYTHONPATH=/tmp/metadata-cleaner-poetry POETRY_CACHE_DIR=/tmp/metadata-cleaner-poetry-cache python3 -m poetry check --lock
- env PYTHONPATH=/tmp/metadata-cleaner-poetry POETRY_CACHE_DIR=/tmp/metadata-cleaner-poetry-cache python3 -m poetry build
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m pip_audit --cache-dir /tmp/metadata-cleaner-pip-audit-cache-2 --path /tmp/metadata-cleaner-test-deps