### PR TITLE
feat: add configurable checksum algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ metadata-cleaner delete ./photos --summary-file reports/summary.json
 ```
 
 Summary reports include per-file status and output paths for audit trails.
-Add `--checksums` to include SHA-256 input/output hashes.
+Add `--checksums` to include input/output hashes. SHA-256 is the default; use
+`--checksum-algorithm sha512` or `--checksum-algorithm blake2b` for stronger
+hash reports.
 Add `--preserve-timestamps` when cleaned files should keep source file times.
 Use `--report-detail compact` or `--report-detail summary` for smaller reports.
 Use `--report-filter failed` to list only failed per-file entries.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## v3.16.0
+**Release Date**: 2026-05-11
+
+### Features
+- Added `metadata-cleaner delete --checksum-algorithm sha256|sha512|blake2b`
+  for configurable checksum reporting.
+- `--checksums` keeps SHA-256 as the default while using algorithm-specific
+  report keys such as `input_sha512` and `output_blake2b` when requested.
+
+### Maintenance
+- Added direct checksum helper coverage and CLI JSON summary coverage for
+  SHA-512 checksum reports.
+
 ## v3.15.0
 **Release Date**: 2026-05-10
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -66,10 +66,11 @@ to write the same summary payload to a file. Delete summaries include top-level
 counts plus a `files` list with each input path, per-file status, output path,
 format-specific processing warnings, and failure reason when available.
 
-Pass `--checksums` with `delete` to include SHA-256 hashes in each per-file
-result. Dry-run summaries include input hashes and leave output hashes empty;
-completed cleaning summaries include both input and output hashes when files are
-available.
+Pass `--checksums` with `delete` to include hashes in each per-file result.
+SHA-256 is the default. Use `--checksum-algorithm sha256|sha512|blake2b` to
+select the report algorithm. Dry-run summaries include input hashes and leave
+output hashes empty; completed cleaning summaries include both input and output
+hashes when files are available.
 
 Use `--report-detail full|compact|summary` to control JSON verbosity. `full` is
 the default and preserves all per-file fields, `compact` keeps minimal per-file

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -25,7 +25,6 @@ privacy risk before implementation.
 ## Medium Term
 
 ### Privacy and Safety
-- Add optional checksum algorithms beyond SHA-256 only if users need them.
 - Add timestamp preservation coverage for additional handlers as new formats are
   added.
 - Expand per-file warnings as handlers gain more precise lossless/rewrite

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -83,6 +83,12 @@ Include SHA-256 checksums in JSON summaries:
 metadata-cleaner delete ./images --summary-file reports/summary.json --checksums
 ```
 
+Choose a different checksum algorithm:
+
+```bash
+metadata-cleaner delete ./images --json-summary --checksums --checksum-algorithm sha512
+```
+
 Control JSON report verbosity for large batches:
 
 ```bash

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -8,6 +8,7 @@ from tqdm import tqdm
 
 from m_c.cli.utils import format_metadata_output
 from m_c.core.file_utils import (
+    SUPPORTED_CHECKSUM_ALGORITHMS,
     get_file_checksum,
     get_safe_output_path,
     get_supported_files,
@@ -288,6 +289,7 @@ def _record_file_result(
     output_path: Optional[str] = None,
     error: Optional[str] = None,
     include_checksums: bool = False,
+    checksum_algorithm: str = "sha256",
 ) -> None:
     item = {
         "input": input_path,
@@ -298,10 +300,12 @@ def _record_file_result(
     if warnings:
         item["warnings"] = warnings
     if include_checksums:
+        input_key = f"input_{checksum_algorithm}"
+        output_key = f"output_{checksum_algorithm}"
         item["checksums"] = {
-            "input_sha256": get_file_checksum(input_path),
-            "output_sha256": (
-                get_file_checksum(output_path)
+            input_key: get_file_checksum(input_path, checksum_algorithm),
+            output_key: (
+                get_file_checksum(output_path, checksum_algorithm)
                 if output_path and os.path.exists(output_path)
                 else None
             ),
@@ -356,7 +360,14 @@ def view(ctx, file, json_output):
 @click.option(
     "--checksums",
     is_flag=True,
-    help="Include SHA-256 checksums in JSON summaries and summary files.",
+    help="Include checksums in JSON summaries and summary files.",
+)
+@click.option(
+    "--checksum-algorithm",
+    type=click.Choice(SUPPORTED_CHECKSUM_ALGORITHMS),
+    default="sha256",
+    show_default=True,
+    help="Checksum algorithm to use when --checksums is enabled.",
 )
 @click.option(
     "--report-detail",
@@ -392,6 +403,7 @@ def delete(
     dry_run,
     json_summary,
     checksums,
+    checksum_algorithm,
     report_detail,
     report_filter,
     preserve_timestamps,
@@ -442,6 +454,7 @@ def delete(
                 "would_process",
                 planned_output,
                 include_checksums=checksums,
+                checksum_algorithm=checksum_algorithm,
             )
             if json_summary:
                 _echo_batch_summary(
@@ -471,6 +484,7 @@ def delete(
                 "success",
                 result,
                 include_checksums=checksums,
+                checksum_algorithm=checksum_algorithm,
             )
             if json_summary:
                 _echo_batch_summary(
@@ -502,6 +516,7 @@ def delete(
                 planned_output,
                 "metadata_removal_failed",
                 include_checksums=checksums,
+                checksum_algorithm=checksum_algorithm,
             )
             if json_summary:
                 _echo_batch_summary(
@@ -550,6 +565,7 @@ def delete(
                         "would_process" if dry_run else "success",
                         output_path if dry_run else result,
                         include_checksums=checksums,
+                        checksum_algorithm=checksum_algorithm,
                     )
                 else:
                     summary.failed += 1
@@ -561,6 +577,7 @@ def delete(
                         output_path,
                         "metadata_removal_failed",
                         include_checksums=checksums,
+                        checksum_algorithm=checksum_algorithm,
                     )
             except Exception as e:
                 summary.failed += 1
@@ -572,6 +589,7 @@ def delete(
                     None,
                     str(e),
                     include_checksums=checksums,
+                    checksum_algorithm=checksum_algorithm,
                 )
                 logger.error(f"Failed to process {file_path}: {e}", exc_info=True)
             pbar.update(1)

--- a/m_c/core/file_utils.py
+++ b/m_c/core/file_utils.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 logger = logging.getLogger("metadata_cleaner")
 
+SUPPORTED_CHECKSUM_ALGORITHMS = ("sha256", "sha512", "blake2b")
+
 
 def validate_file(file_path: str) -> bool:
     """Check if the file exists and is accessible."""
@@ -20,14 +22,19 @@ def validate_file(file_path: str) -> bool:
     return True
 
 
-def get_file_checksum(file_path: str) -> Optional[str]:
-    """Generate SHA-256 checksum for file integrity verification using chunking."""
+def get_file_checksum(file_path: str, algorithm: str = "sha256") -> Optional[str]:
+    """Generate a checksum for file integrity verification using chunking."""
+    algorithm = algorithm.lower()
+    if algorithm not in SUPPORTED_CHECKSUM_ALGORITHMS:
+        logger.error(f"Unsupported checksum algorithm: {algorithm}")
+        return None
+
     try:
-        sha256 = hashlib.sha256()
+        checksum = hashlib.new(algorithm)
         with open(file_path, "rb") as f:
             for chunk in iter(lambda: f.read(8192), b""):
-                sha256.update(chunk)
-        return sha256.hexdigest()
+                checksum.update(chunk)
+        return checksum.hexdigest()
     except Exception as e:
         logger.error(f"Error generating checksum for {file_path}: {e}")
         return None

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -18,7 +18,7 @@ import pypdf
 
 from m_c.cli.main import cli
 from m_c.core.metadata_processor import MetadataProcessor
-from m_c.core.file_utils import validate_file, get_safe_output_path
+from m_c.core.file_utils import get_file_checksum, validate_file, get_safe_output_path
 from m_c.core.logger import logger
 from m_c.handlers.base_handler import BaseHandler
 from m_c.handlers.video_handler import VideoHandler
@@ -173,6 +173,29 @@ class TestMetadataCleaner(unittest.TestCase):
         """Test safe output path generation."""
         output_path = get_safe_output_path(self.test_files["image"], prefix="cleaned_")
         self.assertTrue(os.path.basename(output_path).startswith("cleaned_"))
+
+    def test_get_file_checksum_supports_multiple_algorithms(self):
+        """Checksum helper should support stronger optional algorithms."""
+        checksum_file = os.path.join(self.test_dir, "checksum.txt")
+        with open(checksum_file, "wb") as output_file:
+            output_file.write(b"metadata-cleaner checksum fixture")
+
+        with open(checksum_file, "rb") as input_file:
+            content = input_file.read()
+
+        self.assertEqual(
+            get_file_checksum(checksum_file),
+            hashlib.sha256(content).hexdigest(),
+        )
+        self.assertEqual(
+            get_file_checksum(checksum_file, "sha512"),
+            hashlib.sha512(content).hexdigest(),
+        )
+        self.assertEqual(
+            get_file_checksum(checksum_file, "blake2b"),
+            hashlib.blake2b(content).hexdigest(),
+        )
+        self.assertIsNone(get_file_checksum(checksum_file, "md5"))
 
     def test_view_metadata(self):
         """Test metadata extraction."""
@@ -727,6 +750,34 @@ class TestMetadataCleaner(unittest.TestCase):
             checksums = payload["files"][0]["checksums"]
             self.assertEqual(checksums["input_sha256"], expected_hash)
             self.assertIsNone(checksums["output_sha256"])
+
+    def test_cli_json_summary_with_sha512_checksums(self):
+        """Checksum reporting should support stronger optional algorithms."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Image.new("RGB", (10, 10), color="yellow").save("photo.jpg", "jpeg")
+            with open("photo.jpg", "rb") as image_file:
+                expected_hash = hashlib.sha512(image_file.read()).hexdigest()
+
+            result = runner.invoke(
+                cli,
+                [
+                    "delete",
+                    "photo.jpg",
+                    "--dry-run",
+                    "--json-summary",
+                    "--checksums",
+                    "--checksum-algorithm",
+                    "sha512",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            checksums = payload["files"][0]["checksums"]
+            self.assertEqual(checksums["input_sha512"], expected_hash)
+            self.assertIsNone(checksums["output_sha512"])
+            self.assertNotIn("input_sha256", checksums)
 
     def test_cli_json_summary_includes_processing_warnings(self):
         """JSON summaries should warn when formats use rewrite-style cleanup."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.15.0"
+version = "3.16.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add --checksum-algorithm sha256|sha512|blake2b for delete reports
- keep SHA-256 as the default --checksums behavior while emitting algorithm-specific report keys
- update docs, roadmap, release notes, and checksum helper/CLI test coverage

## Verification
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m pytest
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m flake8 m_c manage.py
- git diff --check
- env PYTHONPATH=/tmp/metadata-cleaner-poetry POETRY_CACHE_DIR=/tmp/metadata-cleaner-poetry-cache python3 -m poetry check --lock
- env PYTHONPATH=/tmp/metadata-cleaner-poetry POETRY_CACHE_DIR=/tmp/metadata-cleaner-poetry-cache python3 -m poetry build
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m pip_audit --cache-dir /tmp/metadata-cleaner-pip-audit-cache-2 --path /tmp/metadata-cleaner-test-deps