### PR TITLE
test: cover timestamp preservation for package documents

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## v3.16.1
+**Release Date**: 2026-05-11
+
+### Maintenance
+- Added timestamp-preservation regression coverage for ODT and EPUB cleanup.
+- Confirmed package-rewrite document handlers honor
+  `preserve_timestamps=True` after metadata removal.
+
 ## v3.16.0
 **Release Date**: 2026-05-11
 

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -25,8 +25,6 @@ privacy risk before implementation.
 ## Medium Term
 
 ### Privacy and Safety
-- Add timestamp preservation coverage for additional handlers as new formats are
-  added.
 - Expand per-file warnings as handlers gain more precise lossless/rewrite
   detection.
 

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -398,6 +398,42 @@ class TestMetadataCleaner(unittest.TestCase):
         self.assertEqual(result, cleaned_file)
         self.assertEqual(int(os.stat(cleaned_file).st_mtime), old_mtime)
 
+    def test_odt_cleanup_preserves_timestamps_when_requested(self):
+        """ODT package cleanup should honor timestamp preservation."""
+        source_odt = os.path.join(self.test_dir, "timestamped.odt")
+        cleaned_odt = os.path.join(self.cleaned_dir, "timestamped_cleaned.odt")
+        self._write_odt(source_odt)
+        old_atime = 1_600_000_000
+        old_mtime = 1_500_000_000
+        os.utime(source_odt, (old_atime, old_mtime))
+
+        result = self.processor.delete_metadata(
+            source_odt,
+            cleaned_odt,
+            preserve_timestamps=True,
+        )
+
+        self.assertEqual(result, cleaned_odt)
+        self.assertEqual(int(os.stat(cleaned_odt).st_mtime), old_mtime)
+
+    def test_epub_cleanup_preserves_timestamps_when_requested(self):
+        """EPUB package cleanup should honor timestamp preservation."""
+        source_epub = os.path.join(self.test_dir, "timestamped.epub")
+        cleaned_epub = os.path.join(self.cleaned_dir, "timestamped_cleaned.epub")
+        self._write_epub(source_epub)
+        old_atime = 1_600_000_000
+        old_mtime = 1_500_000_000
+        os.utime(source_epub, (old_atime, old_mtime))
+
+        result = self.processor.delete_metadata(
+            source_epub,
+            cleaned_epub,
+            preserve_timestamps=True,
+        )
+
+        self.assertEqual(result, cleaned_epub)
+        self.assertEqual(int(os.stat(cleaned_epub).st_mtime), old_mtime)
+
     def test_docx_metadata_removal_clears_core_properties(self):
         """DOCX cleaning should preserve content and clear common core metadata."""
         cleaned_docx = os.path.join(self.cleaned_dir, "cleaned_sample.docx")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.16.0"
+version = "3.16.1"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add ODT and EPUB timestamp-preservation regression tests
- confirm package-rewrite document cleanup honors preserve_timestamps=True
- update roadmap and v3.16.1 release notes

## Verification
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m pytest
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m flake8 m_c manage.py
- git diff --check
- env PYTHONPATH=/tmp/metadata-cleaner-poetry POETRY_CACHE_DIR=/tmp/metadata-cleaner-poetry-cache python3 -m poetry check --lock
- env PYTHONPATH=/tmp/metadata-cleaner-poetry POETRY_CACHE_DIR=/tmp/metadata-cleaner-poetry-cache python3 -m poetry build
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m pip_audit --cache-dir /tmp/metadata-cleaner-pip-audit-cache-2 --path /tmp/metadata-cleaner-test-deps