### PR TITLE
ci: publish Docker images on release tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: Publish Docker Image
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish:
+    name: Build and Publish Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ docker build -t metadata-cleaner .
 docker run --rm -v "$(pwd)/photos:/data" metadata-cleaner delete /data
 ```
 
+Published release images are available from GitHub Container Registry:
+
+```bash
+docker run --rm -v "$(pwd)/photos:/data" ghcr.io/sandy-sp/metadata-cleaner:latest delete /data
+```
+
 ## Logging
 
 By default, logs go to stderr only. To write a log file, opt in explicitly:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## v3.17.0
+**Release Date**: 2026-05-11
+
+### Features
+- Added a GitHub Container Registry publishing workflow for tagged releases.
+- Docker release images are published as `ghcr.io/sandy-sp/metadata-cleaner`
+  with version, minor-version, and `latest` tags.
+
+### Maintenance
+- Documented published Docker image usage and release-process behavior.
+
 ## v3.16.1
 **Release Date**: 2026-05-11
 

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -16,7 +16,8 @@ poetry build
 ```
 
 The CI workflow mirrors these checks, builds the Docker image, and smoke-tests
-the built wheel in a clean virtual environment.
+the built wheel in a clean virtual environment. Tagged releases also publish a
+Docker image to GitHub Container Registry.
 
 ## Dependency Updates
 
@@ -64,4 +65,6 @@ git push origin vX.Y.Z
 ```
 
 The release workflow publishes to PyPI and creates the GitHub release using the
-matching `RELEASE_NOTES.md` section as the release body.
+matching `RELEASE_NOTES.md` section as the release body. The Docker publishing
+workflow runs for the same version tags and publishes `ghcr.io/sandy-sp/metadata-cleaner`
+with `vX.Y.Z`, `X.Y.Z`, `X.Y`, and `latest` tags.

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -29,7 +29,6 @@ privacy risk before implementation.
   detection.
 
 ### Packaging
-- Add a Docker image publishing workflow after Docker builds are covered in CI.
 - Consider standalone executables only after the CLI test suite is broader.
 
 ## Longer Term

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.16.1"
+version = "3.17.0"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add a release-tag workflow that publishes Docker images to GitHub Container Registry
- tag images as vX.Y.Z, X.Y.Z, X.Y, and latest for versioned releases
- document published image usage and release-process behavior

## Verification
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m pytest
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m flake8 m_c manage.py
- git diff --check
- env PYTHONPATH=/tmp/metadata-cleaner-poetry POETRY_CACHE_DIR=/tmp/metadata-cleaner-poetry-cache python3 -m poetry check --lock
- env PYTHONPATH=/tmp/metadata-cleaner-poetry POETRY_CACHE_DIR=/tmp/metadata-cleaner-poetry-cache python3 -m poetry build
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m pip_audit --cache-dir /tmp/metadata-cleaner-pip-audit-cache-2 --path /tmp/metadata-cleaner-test-deps