### PR TITLE
ci: update Docker metadata action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## v3.17.1
+**Release Date**: 2026-05-11
+
+### Maintenance
+- Updated the Docker image publishing workflow to `docker/metadata-action@v6`
+  for Node 24-compatible GitHub Actions runtime support.
+
 ## v3.17.0
 **Release Date**: 2026-05-11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.17.0"
+version = "3.17.1"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- update the Docker publishing workflow to docker/metadata-action@v6
- add v3.17.1 maintenance release notes for Node 24-compatible action runtime support

## Verification
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m pytest
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m flake8 m_c manage.py
- git diff --check
- env PYTHONPATH=/tmp/metadata-cleaner-poetry POETRY_CACHE_DIR=/tmp/metadata-cleaner-poetry-cache python3 -m poetry check --lock
- env PYTHONPATH=/tmp/metadata-cleaner-poetry POETRY_CACHE_DIR=/tmp/metadata-cleaner-poetry-cache python3 -m poetry build
- env PYTHONPATH=/tmp/metadata-cleaner-test-deps python3 -m pip_audit --cache-dir /tmp/metadata-cleaner-pip-audit-cache-2 --path /tmp/metadata-cleaner-test-deps