### PR TITLE
ci: smoke test optional system tools

### DIFF
--- a/.github/scripts/package_smoke.py
+++ b/.github/scripts/package_smoke.py
@@ -1,0 +1,146 @@
+import json
+import os
+import shutil
+import subprocess
+import wave
+from pathlib import Path
+
+import docx
+from PIL import Image
+import pypdf
+
+
+CLI = os.environ.get("METADATA_CLEANER_CLI", "metadata-cleaner")
+ROOT = Path("smoke-files")
+CLEANED = Path("smoke-cleaned")
+REPORT = Path("smoke-report.json")
+
+
+def run_command(command):
+    return subprocess.run(command, check=True, capture_output=True, text=True)
+
+
+def run_cli(*args):
+    return run_command([CLI, *args])
+
+
+def read_json_output(*args):
+    result = run_cli(*args, "--json")
+    return json.loads(result.stdout)
+
+
+def require_tool(name):
+    if not shutil.which(name):
+        raise AssertionError(f"{name} is required for package smoke coverage")
+
+
+def write_fixtures():
+    ROOT.mkdir(exist_ok=True)
+
+    Image.new("RGB", (8, 8), color="white").save(ROOT / "photo.jpg", "jpeg")
+
+    writer = pypdf.PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.add_metadata({"/Title": "Smoke PDF"})
+    with (ROOT / "document.pdf").open("wb") as pdf_file:
+        writer.write(pdf_file)
+
+    document = docx.Document()
+    document.add_paragraph("Metadata Cleaner smoke document.")
+    document.core_properties.title = "Smoke DOCX"
+    document.save(ROOT / "document.docx")
+
+    with wave.open(str(ROOT / "audio.wav"), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(8000)
+        wav_file.writeframes(b"\0\0" * 800)
+
+    run_command(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=size=16x16:rate=1",
+            "-t",
+            "1",
+            "-metadata",
+            "title=Smoke Video",
+            "-pix_fmt",
+            "yuv420p",
+            str(ROOT / "video.mp4"),
+            "-y",
+        ]
+    )
+
+
+def assert_view_payloads():
+    photo_payload = read_json_output("view", str(ROOT / "photo.jpg"))
+    assert photo_payload["status"] == "success", photo_payload
+    assert photo_payload["metadata"].get("FileType") == "JPEG", photo_payload
+
+    pdf_payload = read_json_output("view", str(ROOT / "document.pdf"))
+    assert pdf_payload["status"] == "success", pdf_payload
+    assert pdf_payload["metadata"].get("/Title") == "Smoke PDF", pdf_payload
+
+    docx_payload = read_json_output("view", str(ROOT / "document.docx"))
+    assert docx_payload["status"] == "success", docx_payload
+    assert docx_payload["metadata"].get("title") == "Smoke DOCX", docx_payload
+
+    wav_payload = read_json_output("view", str(ROOT / "audio.wav"))
+    assert wav_payload["status"] in {"success", "no_metadata"}, wav_payload
+
+    video_payload = read_json_output("view", str(ROOT / "video.mp4"))
+    assert video_payload["status"] == "success", video_payload
+    video_title = video_payload["metadata"]["format"]["tags"].get("title")
+    assert video_title == "Smoke Video", video_payload
+
+
+def assert_delete_summary():
+    dry_run = run_cli("delete", str(ROOT), "--dry-run", "--json-summary")
+    dry_run_payload = json.loads(dry_run.stdout)
+    assert dry_run_payload["status"] == "success", dry_run_payload
+    assert dry_run_payload["total"] == 5, dry_run_payload
+    assert dry_run_payload["would_process"] == 5, dry_run_payload
+
+    run_cli(
+        "delete",
+        str(ROOT),
+        "--output",
+        str(CLEANED),
+        "--summary-file",
+        str(REPORT),
+        "--quiet",
+    )
+
+    report = json.loads(REPORT.read_text())
+    assert report["status"] == "success", report
+    assert report["total"] == 5, report
+    assert report["succeeded"] == 5, report
+    assert len(report["files"]) == 5, report
+
+    cleaned_video = CLEANED / "video.mp4"
+    assert cleaned_video.exists(), report
+    cleaned_video_payload = read_json_output("view", str(cleaned_video))
+    cleaned_title = cleaned_video_payload["metadata"]["format"].get("tags", {}).get(
+        "title"
+    )
+    assert cleaned_title != "Smoke Video", cleaned_video_payload
+
+
+def main():
+    require_tool("exiftool")
+    require_tool("ffmpeg")
+    require_tool("ffprobe")
+    run_cli("--help")
+    write_fixtures()
+    assert_view_payloads()
+    assert_delete_summary()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Install optional system tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg libimage-exiftool-perl
+
       - name: Install Poetry
         run: pipx install poetry==2.3.4
 
@@ -83,52 +88,5 @@ jobs:
 
       - name: Smoke test installed CLI
         run: |
-          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner --help
-          /tmp/metadata-cleaner-smoke/bin/python - <<'PY'
-          import os
-          import wave
-
-          import docx
-          from PIL import Image
-          import pypdf
-
-          os.makedirs("smoke-files", exist_ok=True)
-
-          Image.new("RGB", (8, 8), color="white").save(
-              "smoke-files/photo.jpg",
-              "jpeg",
-          )
-
-          writer = pypdf.PdfWriter()
-          writer.add_blank_page(width=72, height=72)
-          writer.add_metadata({"/Title": "Smoke PDF"})
-          with open("smoke-files/document.pdf", "wb") as pdf_file:
-              writer.write(pdf_file)
-
-          document = docx.Document()
-          document.add_paragraph("Metadata Cleaner smoke document.")
-          document.core_properties.title = "Smoke DOCX"
-          document.save("smoke-files/document.docx")
-
-          with wave.open("smoke-files/audio.wav", "wb") as wav_file:
-              wav_file.setnchannels(1)
-              wav_file.setsampwidth(2)
-              wav_file.setframerate(8000)
-              wav_file.writeframes(b"\0\0" * 800)
-          PY
-          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner view smoke-files/photo.jpg --json
-          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner view smoke-files/document.pdf --json
-          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner view smoke-files/document.docx --json
-          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner view smoke-files/audio.wav --json
-          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner delete smoke-files --dry-run --json-summary
-          /tmp/metadata-cleaner-smoke/bin/metadata-cleaner delete smoke-files --output smoke-cleaned --summary-file smoke-report.json --quiet
-          /tmp/metadata-cleaner-smoke/bin/python - <<'PY'
-          import json
-          from pathlib import Path
-
-          report = json.loads(Path("smoke-report.json").read_text())
-          assert report["status"] == "success", report
-          assert report["total"] == 4, report
-          assert report["succeeded"] == 4, report
-          assert len(report["files"]) == 4, report
-          PY
+          METADATA_CLEANER_CLI=/tmp/metadata-cleaner-smoke/bin/metadata-cleaner \
+            /tmp/metadata-cleaner-smoke/bin/python .github/scripts/package_smoke.py

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v3.18.2
+**Release Date**: 2026-05-16
+
+### Maintenance
+- Expanded installed-package smoke coverage to install FFmpeg, FFprobe, and
+  ExifTool in CI before testing the built wheel.
+- Added smoke assertions for ExifTool-backed JPEG metadata viewing and
+  FFmpeg-backed MP4 metadata viewing/removal from the installed CLI.
+
 ## v3.18.1
 **Release Date**: 2026-05-16
 

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -11,8 +11,8 @@ privacy risk before implementation.
 - Add video integration tests that run when FFmpeg and FFprobe are installed.
 - Add fixture assertions for additional audio containers beyond WAV when their
   metadata can be generated without external system tools.
-- Add installed-package smoke coverage for optional system-tool paths when
-  those tools are available in CI.
+- Keep installed-package smoke coverage current as optional system-tool behavior
+  expands.
 
 ### CLI Usability
 - Add optional file output targets for machine-readable command output.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.18.1"
+version = "3.18.2"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- install FFmpeg/FFprobe and ExifTool in the installed-package smoke job
- move package smoke assertions into .github/scripts/package_smoke.py
- assert installed CLI can view ExifTool-backed JPEG metadata
- generate a real MP4 fixture and assert installed CLI removes FFmpeg-backed video metadata
- prepare v3.18.2 release notes and update the roadmap item

## Verification
- `poetry run flake8 m_c manage.py`
- `poetry run pytest` -> 56 passed, 1 skipped
- `python3 -m py_compile .github/scripts/package_smoke.py`
- `poetry check --lock`
- `poetry build`
- `poetry run pip-audit` -> no known vulnerabilities found

Note: the full package smoke helper requires FFmpeg, FFprobe, and ExifTool; GitHub Actions is the authoritative verification for that optional-tool path.