### PR TITLE
test: add FLAC audio fixture coverage

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v3.18.3
+**Release Date**: 2026-05-16
+
+### Maintenance
+- Added generated FLAC fixture coverage for Mutagen-backed audio metadata
+  extraction and cleanup.
+- Verified FLAC cleanup strips Vorbis comments on a copied file while
+  preserving the original file metadata and basic stream properties.
+
 ## v3.18.2
 **Release Date**: 2026-05-16
 

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -9,8 +9,8 @@ privacy risk before implementation.
 
 ### Stronger Fixture Coverage
 - Add video integration tests that run when FFmpeg and FFprobe are installed.
-- Add fixture assertions for additional audio containers beyond WAV when their
-  metadata can be generated without external system tools.
+- Add fixture assertions for additional audio containers beyond WAV/FLAC when
+  their metadata can be generated without external system tools.
 - Keep installed-package smoke coverage current as optional system-tool behavior
   expands.
 

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 import docx
 from mutagen import File as MutagenFile
+from mutagen.flac import FLAC
 from mutagen.id3 import TIT2, TPE1
 from mutagen.wave import WAVE
 from PIL import Image
@@ -49,6 +50,25 @@ class TestMetadataCleaner(unittest.TestCase):
         audio.add_tags()
         audio.tags.add(TIT2(encoding=3, text="Fixture Title"))
         audio.tags.add(TPE1(encoding=3, text="Fixture Artist"))
+        audio.save()
+
+    @staticmethod
+    def _write_tagged_flac(file_path):
+        streaminfo = bytearray(34)
+        streaminfo[0:2] = (16).to_bytes(2, "big")
+        streaminfo[2:4] = (16).to_bytes(2, "big")
+        audio_shape = (8000 << 44) | (0 << 41) | (15 << 36)
+        streaminfo[10:18] = audio_shape.to_bytes(8, "big")
+
+        with open(file_path, "wb") as audio_file:
+            audio_file.write(b"fLaC")
+            audio_file.write(bytes([0x80]))
+            audio_file.write((34).to_bytes(3, "big"))
+            audio_file.write(streaminfo)
+
+        audio = FLAC(file_path)
+        audio["title"] = "Fixture Title"
+        audio["artist"] = "Fixture Artist"
         audio.save()
 
     @staticmethod
@@ -1248,6 +1268,35 @@ class TestMetadataCleaner(unittest.TestCase):
             self.assertEqual(original.getsampwidth(), cleaned.getsampwidth())
             self.assertEqual(original.getframerate(), cleaned.getframerate())
             self.assertEqual(original.getnframes(), cleaned.getnframes())
+
+    def test_generated_flac_metadata_removal_preserves_original(self):
+        """Audio cleanup should strip FLAC Vorbis comments on a copied file."""
+        source_flac = os.path.join(self.test_dir, "generated.flac")
+        cleaned_flac = os.path.join(self.cleaned_dir, "generated_cleaned.flac")
+
+        self._write_tagged_flac(source_flac)
+        source_metadata = self.processor.view_metadata(source_flac)
+        self.assertEqual(source_metadata["title"], ["Fixture Title"])
+        self.assertEqual(source_metadata["artist"], ["Fixture Artist"])
+
+        output_file = self.processor.delete_metadata(source_flac, cleaned_flac)
+
+        self.assertEqual(output_file, cleaned_flac)
+        self.assertTrue(os.path.exists(source_flac))
+        self.assertTrue(os.path.exists(cleaned_flac))
+        self.assertEqual(
+            self.processor.view_metadata(source_flac)["title"],
+            ["Fixture Title"],
+        )
+        self.assertEqual(dict(MutagenFile(cleaned_flac, easy=True)), {})
+        self.assertEqual(
+            FLAC(source_flac).info.sample_rate,
+            FLAC(cleaned_flac).info.sample_rate,
+        )
+        self.assertEqual(
+            FLAC(source_flac).info.channels,
+            FLAC(cleaned_flac).info.channels,
+        )
 
     @unittest.skipUnless(
         shutil.which("ffmpeg") and shutil.which("ffprobe"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.18.2"
+version = "3.18.3"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add a generated FLAC fixture with Vorbis comments using Mutagen only
- verify FLAC metadata extraction and cleanup through MetadataProcessor
- confirm cleanup writes a copied file, preserves source metadata, strips cleaned metadata, and keeps basic stream properties
- prepare v3.18.3 release notes and update the roadmap item

## Verification
- `poetry run pytest m_c/tests/test_metadata_cleaner.py -k "generated_wav or generated_flac"` -> 2 passed
- `poetry run flake8 m_c manage.py`
- `poetry run pytest` -> 57 passed, 1 skipped
- `poetry check --lock`
- `poetry build`
- `poetry run pip-audit` -> no known vulnerabilities found
- `git diff --check`