### PR TITLE
feat: add CLI JSON output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Print metadata for automation:
 metadata-cleaner view sample.jpg --json
 ```
 
+Write metadata JSON to a file:
+
+```bash
+metadata-cleaner view sample.jpg --json-output reports/metadata.json
+```
+
 Remove metadata from one file:
 
 ```bash
@@ -80,6 +86,9 @@ Write a JSON summary report:
 ```bash
 metadata-cleaner delete ./photos --summary-file reports/summary.json
 ```
+
+The shared `--json-output reports/summary.json` option writes the same delete
+summary payload.
 
 Summary reports include per-file status and output paths for audit trails.
 Add `--checksums` to include input/output hashes. SHA-256 is the default; use

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## v3.18.4
+**Release Date**: 2026-05-16
+
+### Features
+- Added `metadata-cleaner view --json-output FILE` to write metadata JSON
+  envelopes directly to disk.
+- Added `metadata-cleaner delete --json-output FILE` as a consistent alias for
+  writing final JSON summaries.
+
+### Maintenance
+- Added CLI coverage for JSON output files on successful and invalid `view`
+  calls, plus the `delete --json-output` summary alias.
+
 ## v3.18.3
 **Release Date**: 2026-05-16
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -58,11 +58,14 @@ The CLI returns stable exit codes for automation:
 
 Use `metadata-cleaner view FILE --json` to get a stable JSON envelope with
 `status`, `file`, `metadata_count`, and `metadata` fields. Invalid file input
-returns exit code `2` with `status` set to `invalid_input`.
+returns exit code `2` with `status` set to `invalid_input`. Use
+`metadata-cleaner view FILE --json-output report.json` to write that envelope
+to a file.
 
 Use `metadata-cleaner delete PATH --json-summary` to print a machine-readable
 summary to stdout, or `metadata-cleaner delete PATH --summary-file report.json`
-to write the same summary payload to a file. Delete summaries include top-level
+to write the same summary payload to a file. `--json-output report.json` is a
+shared alias for the delete summary file. Delete summaries include top-level
 counts plus a `files` list with each input path, per-file status, output path,
 format-specific processing warnings, and failure reason when available.
 

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -15,7 +15,7 @@ privacy risk before implementation.
   expands.
 
 ### CLI Usability
-- Add optional file output targets for machine-readable command output.
+- Extend machine-readable file output targets as new JSON surfaces are added.
 - Add additional report filters only if users need more targeted automation
   views.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -41,6 +41,12 @@ Print metadata in a stable JSON envelope:
 metadata-cleaner view my_photo.jpg --json
 ```
 
+Write metadata JSON to a file:
+
+```bash
+metadata-cleaner view my_photo.jpg --json-output reports/metadata.json
+```
+
 Remove metadata from one file:
 
 ```bash
@@ -75,6 +81,12 @@ Write the summary to a JSON file:
 
 ```bash
 metadata-cleaner delete ./images --summary-file reports/summary.json
+```
+
+You can also use the shared JSON output option:
+
+```bash
+metadata-cleaner delete ./images --json-output reports/summary.json
 ```
 
 Include SHA-256 checksums in JSON summaries:

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -122,6 +122,20 @@ def _write_json_payload(file_path: str, payload: dict) -> bool:
         return False
 
 
+def _write_json_output_file(
+    json_output_file: Optional[str],
+    payload: dict,
+    quiet: bool = False,
+) -> bool:
+    if not json_output_file:
+        return True
+    if _write_json_payload(json_output_file, payload):
+        return True
+    if not quiet:
+        click.echo(f"Failed to write JSON output file: {json_output_file}")
+    return False
+
+
 def _write_summary_file(
     summary_file: Optional[str],
     summary: BatchSummary,
@@ -288,25 +302,37 @@ def cli(verbose, log_file):
 @cli.command()
 @click.argument("file")
 @click.option("--json", "json_output", is_flag=True, help="Print a JSON metadata payload.")
+@click.option(
+    "--json-output",
+    "json_output_file",
+    type=click.Path(dir_okay=False, path_type=str),
+    default=None,
+    help="Write the JSON metadata payload to a file.",
+)
 @click.pass_context
-def view(ctx, file, json_output):
+def view(ctx, file, json_output, json_output_file):
     """View metadata of a file."""
     if not os.path.isfile(file):
         message = "file does not exist or is not a regular file"
+        payload = _metadata_payload(file, {}, "invalid_input")
+        payload["error"] = message
         if json_output:
-            payload = _metadata_payload(file, {}, "invalid_input")
-            payload["error"] = message
             _echo_json(payload)
         else:
             click.echo(f"Error: {message}.")
+        if not _write_json_output_file(json_output_file, payload):
+            ctx.exit(EXIT_FAILURE)
         ctx.exit(EXIT_USAGE)
 
     metadata = MetadataProcessor().view_metadata(file)
+    status = "success" if metadata else "no_metadata"
+    payload = _metadata_payload(file, metadata, status)
     if json_output:
-        status = "success" if metadata else "no_metadata"
-        _echo_json(_metadata_payload(file, metadata, status))
+        _echo_json(payload)
     else:
         click.echo(format_metadata_output(metadata))
+    if not _write_json_output_file(json_output_file, payload):
+        ctx.exit(EXIT_FAILURE)
 
 
 @cli.command()
@@ -347,9 +373,11 @@ def view(ctx, file, json_output):
 )
 @click.option(
     "--summary-file",
+    "--json-output",
+    "summary_file",
     type=click.Path(dir_okay=False, path_type=str),
     default=None,
-    help="Write final summary as JSON to a file.",
+    help="Write final JSON summary to a file.",
 )
 @click.option("--quiet", is_flag=True, help="Suppress progress and human output.")
 @click.pass_context

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -258,6 +258,29 @@ class TestMetadataCleaner(unittest.TestCase):
             self.assertGreaterEqual(payload["metadata_count"], 1)
             self.assertIn("/Title", payload["metadata"])
 
+    def test_cli_view_json_output_file_with_metadata(self):
+        """View command should write a stable JSON envelope to a file."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            writer = pypdf.PdfWriter()
+            writer.add_blank_page(width=72, height=72)
+            writer.add_metadata({"/Title": "Automation Test"})
+            with open("sample.pdf", "wb") as pdf_file:
+                writer.write(pdf_file)
+
+            result = runner.invoke(
+                cli,
+                ["view", "sample.pdf", "--json-output", "metadata/view.json"],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertIn("Automation Test", result.output)
+            with open("metadata/view.json") as payload_file:
+                payload = json.load(payload_file)
+            self.assertEqual(payload["status"], "success")
+            self.assertEqual(payload["file"], "sample.pdf")
+            self.assertEqual(payload["metadata"]["/Title"], "Automation Test")
+
     def test_cli_view_json_output_for_invalid_file(self):
         """JSON view output should stay parseable for invalid input."""
         runner = CliRunner()
@@ -266,6 +289,23 @@ class TestMetadataCleaner(unittest.TestCase):
 
             self.assertEqual(result.exit_code, 2, result.output)
             payload = json.loads(result.output)
+            self.assertEqual(payload["status"], "invalid_input")
+            self.assertEqual(payload["file"], "missing.jpg")
+            self.assertEqual(payload["metadata"], {})
+            self.assertIn("error", payload)
+
+    def test_cli_view_json_output_file_for_invalid_file(self):
+        """View JSON file output should stay parseable for invalid input."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                cli,
+                ["view", "missing.jpg", "--json-output", "metadata/view.json"],
+            )
+
+            self.assertEqual(result.exit_code, 2, result.output)
+            with open("metadata/view.json") as payload_file:
+                payload = json.load(payload_file)
             self.assertEqual(payload["status"], "invalid_input")
             self.assertEqual(payload["file"], "missing.jpg")
             self.assertEqual(payload["metadata"], {})
@@ -875,6 +915,32 @@ class TestMetadataCleaner(unittest.TestCase):
                 file_payload["files"][0]["output"],
                 os.path.join("cleaned", "photo.jpg"),
             )
+
+    def test_cli_delete_json_output_alias_writes_summary_file(self):
+        """Delete command should support the shared JSON output file option."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Image.new("RGB", (10, 10), color="yellow").save("photo.jpg", "jpeg")
+
+            result = runner.invoke(
+                cli,
+                [
+                    "delete",
+                    "photo.jpg",
+                    "--json-summary",
+                    "--json-output",
+                    "reports/delete.json",
+                    "--dry-run",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            stdout_payload = json.loads(result.output)
+            with open("reports/delete.json") as payload_file:
+                file_payload = json.load(payload_file)
+            self.assertEqual(file_payload, stdout_payload)
+            self.assertEqual(file_payload["would_process"], 1)
+            self.assertEqual(file_payload["files"][0]["status"], "would_process")
 
     def test_cli_json_summary_with_checksums_for_dry_run(self):
         """Checksum reporting should include input hashes without writing outputs."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.18.3"
+version = "3.18.4"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add `metadata-cleaner view --json-output FILE` for writing metadata JSON envelopes to disk
- add `metadata-cleaner delete --json-output FILE` as a shared alias for final JSON summaries
- document the new output target and prepare v3.18.4 release notes

## Verification
- `poetry run pytest m_c/tests/test_metadata_cleaner.py -k "json_output or summary_file_with_json_summary"` -> 6 passed
- `poetry run flake8 m_c manage.py`
- `poetry run pytest` -> 60 passed, 1 skipped
- `poetry check --lock`
- `poetry build`
- `poetry run pip-audit` -> no known vulnerabilities found
- `git diff --check`