### PR TITLE
docs: clarify processing warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ hash reports.
 Add `--preserve-timestamps` when cleaned files should keep source file times.
 Use `--report-detail compact` or `--report-detail summary` for smaller reports.
 Use `--report-filter failed` to list only failed per-file entries.
-Formats that rewrite, re-save, or remux data include per-file warnings in JSON
-summary reports.
+Formats that copy, rewrite, re-save, use ExifTool, delete audio tags, or remux
+video include precise per-file processing notes in JSON summary reports.
 
 Edit metadata where supported:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v3.18.5
+**Release Date**: 2026-05-16
+
+### Maintenance
+- Expanded per-file processing warnings to more precisely describe copy-first,
+  package rewrite, image re-save, ExifTool, audio tag deletion, and FFmpeg
+  stream-copy remux paths.
+- Added warning coverage for JPEG, FLAC, and video dry-run JSON summaries.
+
 ## v3.18.4
 **Release Date**: 2026-05-16
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -67,7 +67,9 @@ summary to stdout, or `metadata-cleaner delete PATH --summary-file report.json`
 to write the same summary payload to a file. `--json-output report.json` is a
 shared alias for the delete summary file. Delete summaries include top-level
 counts plus a `files` list with each input path, per-file status, output path,
-format-specific processing warnings, and failure reason when available.
+format-specific processing notes, and failure reason when available. Processing
+notes describe copy, rewrite, re-save, ExifTool, tag deletion, or stream-copy
+remux behavior when applicable.
 
 Pass `--checksums` with `delete` to include hashes in each per-file result.
 SHA-256 is the default. Use `--checksum-algorithm sha256|sha512|blake2b` to

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -25,8 +25,8 @@ privacy risk before implementation.
 ## Medium Term
 
 ### Privacy and Safety
-- Expand per-file warnings as handlers gain more precise lossless/rewrite
-  detection.
+- Keep per-file processing notes current as handlers gain more precise
+  lossless/rewrite/remux detection.
 
 ### Packaging
 - Consider standalone executables only after the CLI test suite is broader.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -143,7 +143,8 @@ JSON summaries include top-level counts and per-file details:
       "status": "success",
       "output": "cleaned-images/photo.jpg",
       "warnings": [
-        "Format-specific processing notes appear here when applicable."
+        "Format-specific processing notes describe copy, rewrite, re-save, "
+        "tag deletion, or remux behavior when applicable."
       ],
       "checksums": {
         "input_sha256": "<sha256>",

--- a/m_c/core/reporting.py
+++ b/m_c/core/reporting.py
@@ -5,46 +5,111 @@ def processing_warnings(file_path: str) -> list[str]:
     """Return format-specific processing warnings for reports and UI surfaces."""
     ext = os.path.splitext(file_path)[1].lower()
     warnings_by_extension = {
+        ".jpg": [
+            "JPEG metadata removal copies the file first and removes EXIF "
+            "tags in-place on the copy when possible; pixel data is not "
+            "re-encoded on that path."
+        ],
+        ".jpeg": [
+            "JPEG metadata removal copies the file first and removes EXIF "
+            "tags in-place on the copy when possible; pixel data is not "
+            "re-encoded on that path."
+        ],
         ".png": [
-            "PNG metadata removal re-saves image data; inspect output if "
-            "pixel-perfect preservation matters."
+            "PNG metadata removal re-saves image data with Pillow because PNG "
+            "text chunks are not stripped in-place; inspect output if "
+            "pixel-perfect binary preservation matters."
+        ],
+        ".tiff": [
+            "TIFF metadata removal copies the file first and removes EXIF tags "
+            "in-place on the copy when possible; Pillow re-save is used only "
+            "as a fallback."
+        ],
+        ".webp": [
+            "WebP metadata removal copies the file first and removes EXIF tags "
+            "in-place on the copy when possible; Pillow re-save is used only "
+            "as a fallback."
         ],
         ".pdf": [
-            "PDF metadata removal rewrites the document container while "
-            "preserving content."
+            "PDF metadata removal rewrites the PDF container and removes "
+            "document info/XMP metadata while preserving page content."
         ],
         ".docx": [
-            "DOCX metadata removal rewrites the document package while "
-            "preserving content."
+            "DOCX metadata removal rewrites the Office package and clears "
+            "core properties while preserving document content."
+        ],
+        ".avif": [
+            "AVIF metadata removal requires ExifTool and strips metadata on a "
+            "copied file without intentionally re-encoding image pixels."
         ],
         ".heic": [
-            "HEIC metadata removal requires ExifTool and rewrites metadata on "
-            "a copied file."
+            "HEIC metadata removal requires ExifTool and strips metadata on a "
+            "copied file without intentionally re-encoding image pixels."
         ],
         ".heif": [
-            "HEIF metadata removal requires ExifTool and rewrites metadata on "
-            "a copied file."
+            "HEIF metadata removal requires ExifTool and strips metadata on a "
+            "copied file without intentionally re-encoding image pixels."
         ],
         ".epub": [
-            "EPUB metadata removal rewrites the book package while preserving "
-            "content."
+            "EPUB metadata removal rewrites the book package and neutralizes "
+            "package metadata while preserving manifest content."
         ],
         ".odt": [
-            "ODT metadata removal rewrites the document package while "
-            "preserving content."
+            "ODT metadata removal rewrites the OpenDocument package and clears "
+            "meta.xml while preserving document content."
         ],
-        ".mp3": ["Audio metadata removal rewrites tags on a copied audio file."],
-        ".wav": ["Audio metadata removal rewrites tags on a copied audio file."],
-        ".flac": ["Audio metadata removal rewrites tags on a copied audio file."],
-        ".ogg": ["Audio metadata removal rewrites tags on a copied audio file."],
-        ".aac": ["Audio metadata removal rewrites tags on a copied audio file."],
-        ".m4a": ["Audio metadata removal rewrites tags on a copied audio file."],
-        ".wma": ["Audio metadata removal rewrites tags on a copied audio file."],
-        ".mp4": ["Video metadata removal remuxes the container with stream copy."],
-        ".mkv": ["Video metadata removal remuxes the container with stream copy."],
-        ".mov": ["Video metadata removal remuxes the container with stream copy."],
-        ".avi": ["Video metadata removal remuxes the container with stream copy."],
-        ".webm": ["Video metadata removal remuxes the container with stream copy."],
-        ".flv": ["Video metadata removal remuxes the container with stream copy."],
+        ".mp3": [
+            "Audio metadata removal copies the file first, then Mutagen deletes "
+            "tags on the copy; audio frames are not intentionally re-encoded."
+        ],
+        ".wav": [
+            "Audio metadata removal copies the file first, then Mutagen deletes "
+            "tags on the copy; audio samples are not intentionally re-encoded."
+        ],
+        ".flac": [
+            "FLAC metadata removal copies the file first, then Mutagen deletes "
+            "Vorbis comments on the copy; audio frames are not intentionally "
+            "re-encoded."
+        ],
+        ".ogg": [
+            "Audio metadata removal copies the file first, then Mutagen deletes "
+            "tags on the copy; audio frames are not intentionally re-encoded."
+        ],
+        ".aac": [
+            "Audio metadata removal copies the file first, then Mutagen deletes "
+            "tags on the copy; audio frames are not intentionally re-encoded."
+        ],
+        ".m4a": [
+            "Audio metadata removal copies the file first, then Mutagen deletes "
+            "tags on the copy; audio frames are not intentionally re-encoded."
+        ],
+        ".wma": [
+            "Audio metadata removal copies the file first, then Mutagen deletes "
+            "tags on the copy; audio frames are not intentionally re-encoded."
+        ],
+        ".mp4": [
+            "Video metadata removal remuxes the container with FFmpeg stream "
+            "copy; media streams are not intentionally re-encoded."
+        ],
+        ".mkv": [
+            "Video metadata removal remuxes the container with FFmpeg stream "
+            "copy; media streams are not intentionally re-encoded."
+        ],
+        ".mov": [
+            "Video metadata removal remuxes the container with FFmpeg stream "
+            "copy; media streams are not intentionally re-encoded."
+        ],
+        ".avi": [
+            "Video metadata removal remuxes the container with FFmpeg stream "
+            "copy; media streams are not intentionally re-encoded."
+        ],
+        ".webm": [
+            "Video metadata removal remuxes the container with FFmpeg stream "
+            "copy; media streams are not intentionally re-encoded."
+        ],
+        ".flv": [
+            "Video metadata removal remuxes the container with FFmpeg stream "
+            "copy; media streams are not intentionally re-encoded."
+        ],
     }
     return warnings_by_extension.get(ext, [])

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -1005,6 +1005,22 @@ class TestMetadataCleaner(unittest.TestCase):
             warnings = payload["files"][0]["warnings"]
             self.assertTrue(any("re-saves image data" in warning for warning in warnings))
 
+    def test_cli_json_summary_includes_jpeg_processing_warning(self):
+        """JPEG dry-run reports should describe copy-first EXIF cleanup."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Image.new("RGB", (10, 10), color="yellow").save("photo.jpg", "jpeg")
+
+            result = runner.invoke(
+                cli,
+                ["delete", "photo.jpg", "--dry-run", "--json-summary"],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            warnings = payload["files"][0]["warnings"]
+            self.assertTrue(any("pixel data is not re-encoded" in warning for warning in warnings))
+
     def test_cli_json_summary_includes_odt_processing_warning(self):
         """ODT dry-run reports should describe package rewrite behavior."""
         runner = CliRunner()
@@ -1060,6 +1076,39 @@ class TestMetadataCleaner(unittest.TestCase):
                 any("HEIC metadata removal requires ExifTool" in warning
                     for warning in warnings)
             )
+
+    def test_cli_json_summary_includes_flac_processing_warning(self):
+        """FLAC dry-run reports should describe copied tag cleanup."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            self._write_tagged_flac("song.flac")
+
+            result = runner.invoke(
+                cli,
+                ["delete", "song.flac", "--dry-run", "--json-summary"],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            warnings = payload["files"][0]["warnings"]
+            self.assertTrue(any("Vorbis comments" in warning for warning in warnings))
+
+    def test_cli_json_summary_includes_video_processing_warning(self):
+        """Video dry-run reports should describe stream-copy remux behavior."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("clip.mp4", "wb") as video_file:
+                video_file.write(b"dummy binary data")
+
+            result = runner.invoke(
+                cli,
+                ["delete", "clip.mp4", "--dry-run", "--json-summary"],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            payload = json.loads(result.output)
+            warnings = payload["files"][0]["warnings"]
+            self.assertTrue(any("stream copy" in warning for warning in warnings))
 
     def test_cli_json_summary_compact_report_detail(self):
         """Compact JSON reports should omit verbose per-file fields."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.18.4"
+version = "3.18.5"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- expand per-file processing notes for copy-first, package rewrite, image re-save, ExifTool, Mutagen tag deletion, and FFmpeg stream-copy remux paths
- add warning coverage for JPEG, FLAC, and video dry-run JSON summaries
- prepare v3.18.5 release notes and roadmap update

## Verification
- `poetry run pytest m_c/tests/test_metadata_cleaner.py -k "processing_warning"` -> 7 passed
- `poetry run flake8 m_c manage.py`
- `poetry run pytest` -> 63 passed, 1 skipped
- `poetry check --lock`
- `poetry build`
- `poetry run pip-audit` -> no known vulnerabilities found
- `git diff --check`