### PR TITLE
fix: report unsupported single-file inputs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## v3.18.7
+**Release Date**: 2026-05-16
+
+### CLI
+- Added explicit unsupported single-file handling for `view` and `delete`
+  commands.
+- Machine-readable output now returns `unsupported_file_type` for unsupported
+  `view` input and `unsupported_input` summaries for unsupported `delete`
+  input, instead of reporting those files as no-metadata or processing
+  failures.
+
 ## v3.18.6
 **Release Date**: 2026-05-16
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -60,7 +60,8 @@ Use `metadata-cleaner view FILE --json` to get a stable JSON envelope with
 `status`, `file`, `metadata_count`, and `metadata` fields. Invalid file input
 returns exit code `2` with `status` set to `invalid_input`. Use
 `metadata-cleaner view FILE --json-output report.json` to write that envelope
-to a file.
+to a file. Existing files with unsupported extensions return exit code `2` with
+`status` set to `unsupported_file_type`.
 
 Use `metadata-cleaner delete PATH --json-summary` to print a machine-readable
 summary to stdout, or `metadata-cleaner delete PATH --summary-file report.json`
@@ -70,6 +71,10 @@ counts plus a `files` list with each input path, per-file status, output path,
 format-specific processing notes, and failure reason when available. Processing
 notes describe copy, rewrite, re-save, ExifTool, tag deletion, or stream-copy
 remux behavior when applicable.
+
+Existing single-file delete inputs with unsupported extensions return exit code
+`2`, top-level `status` set to `unsupported_input`, and a per-file status of
+`unsupported`.
 
 Pass `--checksums` with `delete` to include hashes in each per-file result.
 SHA-256 is the default. Use `--checksum-algorithm sha256|sha512|blake2b` to

--- a/docs/REPO_HEALTH_REVIEW.md
+++ b/docs/REPO_HEALTH_REVIEW.md
@@ -65,11 +65,8 @@ review.
 
 ## Next Recommended Work
 
-1. Add explicit CLI handling for unsupported single-file inputs so `view` and
-   `delete` return an unsupported-input status instead of treating the file as
-   no metadata or a processing failure.
-2. Add timeouts to ExifTool subprocess calls, matching the FFmpeg timeout
+1. Add timeouts to ExifTool subprocess calls, matching the FFmpeg timeout
    posture.
-3. Add archive safety limits for EPUB/ODT package reads to reduce zip-bomb style
+2. Add archive safety limits for EPUB/ODT package reads to reduce zip-bomb style
    denial-of-service risk.
-4. Evaluate `pikepdf` v10 in a dedicated compatibility branch with PDF fixtures.
+3. Evaluate `pikepdf` v10 in a dedicated compatibility branch with PDF fixtures.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -177,7 +177,8 @@ metadata-cleaner edit song.mp3 --changes '{"artist": "Unknown"}'
 
 - `0`: command completed successfully.
 - `1`: command ran but all processing failed.
-- `2`: invalid input, usage issue, or no supported files were found.
+- `2`: invalid input, unsupported single-file input, usage issue, or no
+  supported files were found.
 - `3`: batch processing completed with partial failures.
 
 ## Supported Formats

--- a/m_c/cli/main.py
+++ b/m_c/cli/main.py
@@ -12,6 +12,7 @@ from m_c.core.file_utils import (
     get_file_checksum,
     get_safe_output_path,
     get_supported_files,
+    is_supported_file,
 )
 from m_c.core.logger import configure_logging, logger
 from m_c.core.metadata_processor import MetadataProcessor
@@ -36,6 +37,8 @@ class BatchSummary:
 def _summary_status(summary: BatchSummary, dry_run: bool) -> str:
     if summary.total == 0:
         return "no_supported_files"
+    if summary.skipped == summary.total:
+        return "unsupported_input"
     if dry_run:
         return "success" if summary.failed == 0 else "partial_failure"
     if summary.succeeded == summary.total:
@@ -324,6 +327,18 @@ def view(ctx, file, json_output, json_output_file):
             ctx.exit(EXIT_FAILURE)
         ctx.exit(EXIT_USAGE)
 
+    if not is_supported_file(file):
+        message = "unsupported file type"
+        payload = _metadata_payload(file, {}, "unsupported_file_type")
+        payload["error"] = message
+        if json_output:
+            _echo_json(payload)
+        else:
+            click.echo(f"Error: {message}.")
+        if not _write_json_output_file(json_output_file, payload):
+            ctx.exit(EXIT_FAILURE)
+        ctx.exit(EXIT_USAGE)
+
     metadata = MetadataProcessor().view_metadata(file)
     status = "success" if metadata else "no_metadata"
     payload = _metadata_payload(file, metadata, status)
@@ -396,6 +411,38 @@ def delete(
     quiet,
 ):
     """Remove metadata from a file or supported files in a directory."""
+    if os.path.isfile(path) and not is_supported_file(path):
+        summary = BatchSummary(total=1, skipped=1)
+        _record_file_result(
+            summary,
+            path,
+            "unsupported",
+            None,
+            "unsupported_file_type",
+            include_checksums=checksums,
+            checksum_algorithm=checksum_algorithm,
+        )
+        if json_summary:
+            _echo_batch_summary(
+                summary,
+                dry_run,
+                json_summary=True,
+                report_detail=report_detail,
+                report_filter=report_filter,
+            )
+        elif not quiet:
+            click.echo("Unsupported file type.")
+        if not _write_summary_file(
+            summary_file,
+            summary,
+            dry_run,
+            report_detail=report_detail,
+            report_filter=report_filter,
+            quiet=quiet,
+        ):
+            ctx.exit(EXIT_FAILURE)
+        ctx.exit(EXIT_USAGE)
+
     files_to_process = get_supported_files(path)
     if not files_to_process:
         summary = BatchSummary(total=0)

--- a/m_c/core/file_utils.py
+++ b/m_c/core/file_utils.py
@@ -98,19 +98,24 @@ ALL_SUPPORTED_EXTENSIONS = {
 }
 
 
+def is_supported_file(file_path: str) -> bool:
+    """Return whether a path has an extension supported by Metadata Cleaner."""
+    ext = os.path.splitext(file_path)[1].lower()
+    return ext in ALL_SUPPORTED_EXTENSIONS
+
+
 def get_supported_files(path: str) -> list[str]:
     """
     Get all supported files from a directory recursively, or return the file itself.
     """
     if os.path.isfile(path):
-        return [path]
+        return [path] if is_supported_file(path) else []
 
     files_list = []
     if os.path.isdir(path):
         for root, _, files in os.walk(path):
             for file in files:
-                ext = os.path.splitext(file)[1].lower()
-                if ext in ALL_SUPPORTED_EXTENSIONS:
+                if is_supported_file(file):
                     files_list.append(os.path.join(root, file))
 
     return sorted(files_list)

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -311,6 +311,42 @@ class TestMetadataCleaner(unittest.TestCase):
             self.assertEqual(payload["metadata"], {})
             self.assertIn("error", payload)
 
+    def test_cli_view_json_output_for_unsupported_file(self):
+        """View JSON output should explicitly identify unsupported files."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("README.md", "w", encoding="utf-8") as markdown_file:
+                markdown_file.write("# Unsupported\n")
+
+            result = runner.invoke(cli, ["view", "README.md", "--json"])
+
+            self.assertEqual(result.exit_code, 2, result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["status"], "unsupported_file_type")
+            self.assertEqual(payload["file"], "README.md")
+            self.assertEqual(payload["metadata"], {})
+            self.assertEqual(payload["error"], "unsupported file type")
+
+    def test_cli_view_json_output_file_for_unsupported_file(self):
+        """Unsupported view input should still write JSON output files."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("README.md", "w", encoding="utf-8") as markdown_file:
+                markdown_file.write("# Unsupported\n")
+
+            result = runner.invoke(
+                cli,
+                ["view", "README.md", "--json-output", "metadata/view.json"],
+            )
+
+            self.assertEqual(result.exit_code, 2, result.output)
+            with open("metadata/view.json") as payload_file:
+                payload = json.load(payload_file)
+            self.assertEqual(payload["status"], "unsupported_file_type")
+            self.assertEqual(payload["file"], "README.md")
+            self.assertEqual(payload["metadata"], {})
+            self.assertEqual(payload["error"], "unsupported file type")
+
     def test_remove_metadata(self):
         """Test metadata removal for all file types while preserving originals."""
         for category, file_path in self.test_files.items():
@@ -1300,6 +1336,67 @@ class TestMetadataCleaner(unittest.TestCase):
                 payload = json.load(summary_file)
             self.assertEqual(payload["status"], "no_supported_files")
             self.assertEqual(payload["total"], 0)
+
+    def test_cli_delete_unsupported_single_file_exit_code(self):
+        """Delete should distinguish unsupported single files from failures."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("README.md", "w", encoding="utf-8") as markdown_file:
+                markdown_file.write("# Unsupported\n")
+
+            result = runner.invoke(cli, ["delete", "README.md"])
+
+            self.assertEqual(result.exit_code, 2, result.output)
+            self.assertIn("Unsupported file type.", result.output)
+            self.assertFalse(os.path.exists(os.path.join("cleaned", "README.md")))
+
+    def test_cli_delete_unsupported_single_file_json_summary(self):
+        """JSON delete summaries should identify unsupported single files."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("README.md", "w", encoding="utf-8") as markdown_file:
+                markdown_file.write("# Unsupported\n")
+
+            result = runner.invoke(
+                cli,
+                ["delete", "README.md", "--json-summary", "--quiet"],
+            )
+
+            self.assertEqual(result.exit_code, 2, result.output)
+            payload = json.loads(result.output)
+            self.assertEqual(payload["status"], "unsupported_input")
+            self.assertEqual(payload["total"], 1)
+            self.assertEqual(payload["skipped"], 1)
+            self.assertEqual(payload["files"][0]["status"], "unsupported")
+            self.assertEqual(payload["files"][0]["error"], "unsupported_file_type")
+
+    def test_cli_delete_unsupported_single_file_summary_file(self):
+        """Unsupported single files should write summary files for automation."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("README.md", "w", encoding="utf-8") as markdown_file:
+                markdown_file.write("# Unsupported\n")
+
+            result = runner.invoke(
+                cli,
+                [
+                    "delete",
+                    "README.md",
+                    "--summary-file",
+                    "summary.json",
+                    "--quiet",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 2, result.output)
+            self.assertEqual(result.output, "")
+            with open("summary.json") as summary_file:
+                payload = json.load(summary_file)
+            self.assertEqual(payload["status"], "unsupported_input")
+            self.assertEqual(payload["total"], 1)
+            self.assertEqual(payload["skipped"], 1)
+            self.assertEqual(payload["files"][0]["status"], "unsupported")
+            self.assertEqual(payload["files"][0]["error"], "unsupported_file_type")
 
     def test_cli_verbose_log_file_option(self):
         """Global CLI options should enable explicit file logging."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.18.6"
+version = "3.18.7"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- report unsupported existing files explicitly in `view` as `unsupported_file_type`
- report unsupported single-file `delete` inputs as `unsupported_input` summaries with per-file `unsupported` status
- tighten supported-file discovery so single-file paths are extension-filtered like directory inputs
- document the new machine-readable statuses and prepare v3.18.7 release notes

## Verification
- `poetry run pytest m_c/tests/test_metadata_cleaner.py -k "unsupported_single_file or unsupported_file"` -> 5 passed
- `poetry check --lock`
- `poetry run pytest` -> 68 passed, 1 skipped
- `poetry run flake8 m_c manage.py`
- `poetry run pip-audit` -> no known vulnerabilities found
- `poetry build`
- verified v3.18.7 wheel metadata and no shipped test module
- `git diff --check`