### PR TITLE
fix: bound exiftool subprocess calls

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v3.18.8
+**Release Date**: 2026-05-16
+
+### Security
+- Added bounded ExifTool subprocess timeouts for metadata extraction and
+  metadata removal paths.
+- Timed-out ExifTool removals now clean up copied partial outputs before
+  returning failure.
+
 ## v3.18.7
 **Release Date**: 2026-05-16
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,7 +22,8 @@ Metadata Cleaner is a small Python CLI organized around file-type handlers.
 ## Handlers
 
 - `ImageHandler`: uses ExifTool when available for AVIF, `piexif` for lossless
-  EXIF removal from JPEG/WebP/TIFF, and Pillow fallback re-save for other images.
+  EXIF removal from JPEG/WebP/TIFF, and Pillow fallback re-save for other
+  images. ExifTool subprocess calls use bounded timeouts.
 - `DocumentHandler`: uses `pypdf` for PDF metadata reads, `pikepdf` for PDF
   metadata removal, and `python-docx` for DOCX core property cleanup.
 - `AudioHandler`: uses Mutagen and writes cleaned copies before modifying tags.
@@ -38,5 +39,7 @@ Metadata Cleaner is a small Python CLI organized around file-type handlers.
 - Static analysis is performed with CodeQL.
 - Docker image builds are checked in CI so Dockerfile updates are tested before
   release.
+- External ExifTool, FFprobe, and FFmpeg subprocess calls use timeouts so
+  malformed files cannot make those tool invocations wait indefinitely.
 - The project ignores local logs, local agent state, virtual environments, build
   artifacts, and caches.

--- a/docs/REPO_HEALTH_REVIEW.md
+++ b/docs/REPO_HEALTH_REVIEW.md
@@ -65,8 +65,6 @@ review.
 
 ## Next Recommended Work
 
-1. Add timeouts to ExifTool subprocess calls, matching the FFmpeg timeout
-   posture.
-2. Add archive safety limits for EPUB/ODT package reads to reduce zip-bomb style
+1. Add archive safety limits for EPUB/ODT package reads to reduce zip-bomb style
    denial-of-service risk.
-3. Evaluate `pikepdf` v10 in a dedicated compatibility branch with PDF fixtures.
+2. Evaluate `pikepdf` v10 in a dedicated compatibility branch with PDF fixtures.

--- a/m_c/handlers/base_handler.py
+++ b/m_c/handlers/base_handler.py
@@ -14,6 +14,7 @@ class BaseHandler:
     """
 
     SUPPORTED_FORMATS = set()
+    EXIFTOOL_TIMEOUT_SECONDS = 60
 
     def prepare_output_path(
         self, file_path: str, output_path: Optional[str] = None
@@ -55,9 +56,16 @@ class BaseHandler:
                 capture_output=True,
                 text=True,
                 check=True,
+                timeout=self.EXIFTOOL_TIMEOUT_SECONDS,
             )
             data = json.loads(result.stdout)
             return data[0] if data else {}
+        except subprocess.TimeoutExpired:
+            logger.error(
+                "ExifTool extraction timed out for "
+                f"{file_path} after {self.EXIFTOOL_TIMEOUT_SECONDS}s"
+            )
+            return None
         except Exception as e:
             logger.error(f"ExifTool extraction failed for {file_path}: {e}")
             return None
@@ -75,10 +83,24 @@ class BaseHandler:
                 check=True,
                 capture_output=True,
                 text=True,
+                timeout=self.EXIFTOOL_TIMEOUT_SECONDS,
             )
             return target
+        except subprocess.TimeoutExpired:
+            logger.error(
+                "ExifTool removal timed out for "
+                f"{file_path} after {self.EXIFTOOL_TIMEOUT_SECONDS}s"
+            )
+            if os.path.exists(target):
+                os.remove(target)
+            return None
         except subprocess.CalledProcessError as e:
             logger.error(f"ExifTool removal failed for {file_path}: {e.stderr}")
+            if os.path.exists(target):
+                os.remove(target)
+            return None
+        except Exception as e:
+            logger.error(f"ExifTool removal failed for {file_path}: {e}")
             if os.path.exists(target):
                 os.remove(target)
             return None

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -711,6 +711,64 @@ class TestMetadataCleaner(unittest.TestCase):
         self.assertIsNone(result)
         self.assertTrue(os.path.exists(self.test_files["image"]))
 
+    def test_exiftool_extract_uses_timeout(self):
+        """ExifTool extraction should be bounded by a subprocess timeout."""
+        handler = BaseHandler()
+        completed = subprocess.CompletedProcess(
+            args=["exiftool"],
+            returncode=0,
+            stdout='[{"FileType": "JPEG"}]',
+            stderr="",
+        )
+
+        with patch("m_c.handlers.base_handler.subprocess.run", return_value=completed) as run:
+            metadata = handler._extract_metadata_exiftool("photo.jpg")
+
+        self.assertEqual(metadata["FileType"], "JPEG")
+        self.assertEqual(
+            run.call_args.kwargs["timeout"],
+            handler.EXIFTOOL_TIMEOUT_SECONDS,
+        )
+
+    def test_exiftool_extract_timeout_returns_none(self):
+        """ExifTool extraction timeouts should fail predictably."""
+        handler = BaseHandler()
+
+        with patch(
+            "m_c.handlers.base_handler.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(
+                cmd=["exiftool"],
+                timeout=handler.EXIFTOOL_TIMEOUT_SECONDS,
+            ),
+        ):
+            metadata = handler._extract_metadata_exiftool("photo.jpg")
+
+        self.assertIsNone(metadata)
+
+    def test_exiftool_remove_timeout_removes_partial_output(self):
+        """Timed-out ExifTool removals should clean up copied output files."""
+        handler = BaseHandler()
+        source_file = os.path.join(self.test_dir, "source.heic")
+        output_file = os.path.join(self.cleaned_dir, "source.heic")
+        with open(source_file, "wb") as image_file:
+            image_file.write(b"dummy image data")
+
+        with patch(
+            "m_c.handlers.base_handler.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(
+                cmd=["exiftool"],
+                timeout=handler.EXIFTOOL_TIMEOUT_SECONDS,
+            ),
+        ) as run:
+            result = handler._remove_metadata_exiftool(source_file, output_file)
+
+        self.assertIsNone(result)
+        self.assertFalse(os.path.exists(output_file))
+        self.assertEqual(
+            run.call_args.kwargs["timeout"],
+            handler.EXIFTOOL_TIMEOUT_SECONDS,
+        )
+
     def test_cli_delete_dry_run_directory_has_no_file_system_side_effects(self):
         """CLI dry-run mode should not create an output directory."""
         runner = CliRunner()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.18.7"
+version = "3.18.8"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add a 60-second timeout to ExifTool metadata extraction and removal subprocess calls
- clean up copied partial outputs when ExifTool removal times out
- add timeout regression coverage and update architecture/security docs
- prepare v3.18.8 release notes

## Verification
- `poetry run pytest m_c/tests/test_metadata_cleaner.py -k exiftool` -> 4 passed
- `poetry check --lock`
- `poetry run pytest` -> 71 passed, 1 skipped
- `poetry run flake8 m_c manage.py`
- `poetry run pip-audit` -> no known vulnerabilities found
- `poetry build`
- verified v3.18.8 wheel metadata and no shipped test module
- `git diff --check`