### PR TITLE
fix: enforce archive safety limits

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v3.18.9
+**Release Date**: 2026-05-16
+
+### Security
+- Added ZIP archive safety limits for EPUB and ODT metadata extraction and
+  cleanup paths.
+- Oversized archive entries, excessive entry counts, and excessive total
+  uncompressed archive sizes now fail before package members are parsed or
+  rewritten.
+
 ## v3.18.8
 **Release Date**: 2026-05-16
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -98,3 +98,7 @@ creates a cleaned copy, and then displays cleaned-copy metadata for comparison.
 The original file is never modified. The local file browser lists uploaded
 originals and cleaned copies from the current Web UI workspace, and supports
 viewing or deleting those managed files.
+
+EPUB and ODT inputs are ZIP-based packages. Metadata extraction and cleanup
+apply archive safety limits before reading package members so excessive entry
+counts or uncompressed sizes fail instead of being parsed or rewritten.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,7 +25,9 @@ Metadata Cleaner is a small Python CLI organized around file-type handlers.
   EXIF removal from JPEG/WebP/TIFF, and Pillow fallback re-save for other
   images. ExifTool subprocess calls use bounded timeouts.
 - `DocumentHandler`: uses `pypdf` for PDF metadata reads, `pikepdf` for PDF
-  metadata removal, and `python-docx` for DOCX core property cleanup.
+  metadata removal, and `python-docx` for DOCX core property cleanup. EPUB and
+  ODT ZIP packages are checked against entry-count and uncompressed-size limits
+  before package members are parsed or rewritten.
 - `AudioHandler`: uses Mutagen and writes cleaned copies before modifying tags.
 - `VideoHandler`: uses FFprobe for metadata reads and FFmpeg stream copy for
   metadata removal without re-encoding.
@@ -41,5 +43,7 @@ Metadata Cleaner is a small Python CLI organized around file-type handlers.
   release.
 - External ExifTool, FFprobe, and FFmpeg subprocess calls use timeouts so
   malformed files cannot make those tool invocations wait indefinitely.
+- EPUB and ODT ZIP package handling enforces archive safety limits to reduce
+  zip-bomb style denial-of-service risk.
 - The project ignores local logs, local agent state, virtual environments, build
   artifacts, and caches.

--- a/docs/REPO_HEALTH_REVIEW.md
+++ b/docs/REPO_HEALTH_REVIEW.md
@@ -65,6 +65,4 @@ review.
 
 ## Next Recommended Work
 
-1. Add archive safety limits for EPUB/ODT package reads to reduce zip-bomb style
-   denial-of-service risk.
-2. Evaluate `pikepdf` v10 in a dedicated compatibility branch with PDF fixtures.
+1. Evaluate `pikepdf` v10 in a dedicated compatibility branch with PDF fixtures.

--- a/m_c/handlers/document_handler.py
+++ b/m_c/handlers/document_handler.py
@@ -22,6 +22,10 @@ class DocumentHandler(BaseHandler):
     """
 
     SUPPORTED_FORMATS = {"pdf", "docx", "epub", "odt", "txt"}
+    MAX_ZIP_ENTRIES = 4096
+    MAX_ZIP_UNCOMPRESSED_BYTES = 512 * 1024 * 1024
+    MAX_ZIP_MEMBER_BYTES = 128 * 1024 * 1024
+    MAX_METADATA_XML_BYTES = 16 * 1024 * 1024
     ODT_NAMESPACES = {
         "office": "urn:oasis:names:tc:opendocument:xmlns:office:1.0",
         "dc": "http://purl.org/dc/elements/1.1/",
@@ -180,12 +184,61 @@ class DocumentHandler(BaseHandler):
                 return child
         return None
 
+    def _validate_zip_archive(
+        self,
+        archive: zipfile.ZipFile,
+        file_path: str,
+    ) -> list[zipfile.ZipInfo]:
+        """Validate basic ZIP limits before reading archive members."""
+        infos = archive.infolist()
+        if len(infos) > self.MAX_ZIP_ENTRIES:
+            raise ValueError(
+                f"Archive has too many entries: {len(infos)} "
+                f"(max {self.MAX_ZIP_ENTRIES})"
+            )
+
+        total_uncompressed = 0
+        for info in infos:
+            if info.file_size > self.MAX_ZIP_MEMBER_BYTES:
+                raise ValueError(
+                    f"Archive member is too large: {info.filename} "
+                    f"({info.file_size} bytes)"
+                )
+            total_uncompressed += info.file_size
+            if total_uncompressed > self.MAX_ZIP_UNCOMPRESSED_BYTES:
+                raise ValueError(
+                    "Archive uncompressed size exceeds limit: "
+                    f"{file_path} ({total_uncompressed} bytes)"
+                )
+        return infos
+
+    def _read_zip_member(
+        self,
+        archive: zipfile.ZipFile,
+        member_name: str,
+        max_bytes: Optional[int] = None,
+    ) -> bytes:
+        """Read a ZIP member only after checking its declared uncompressed size."""
+        info = archive.getinfo(member_name)
+        limit = max_bytes or self.MAX_ZIP_MEMBER_BYTES
+        if info.file_size > limit:
+            raise ValueError(
+                f"Archive member is too large: {member_name} "
+                f"({info.file_size} bytes)"
+            )
+        return archive.read(member_name)
+
     def _extract_metadata_odt(self, file_path: str) -> Optional[Dict[str, Any]]:
         """Extract common OpenDocument metadata from meta.xml."""
         try:
             with zipfile.ZipFile(file_path, "r") as archive:
+                self._validate_zip_archive(archive, file_path)
                 try:
-                    metadata_xml = archive.read("meta.xml")
+                    metadata_xml = self._read_zip_member(
+                        archive,
+                        "meta.xml",
+                        max_bytes=self.MAX_METADATA_XML_BYTES,
+                    )
                 except KeyError:
                     return {}
 
@@ -220,9 +273,10 @@ class DocumentHandler(BaseHandler):
             wrote_metadata = False
 
             with zipfile.ZipFile(file_path, "r") as source:
+                self._validate_zip_archive(source, file_path)
                 with zipfile.ZipFile(output_path, "w") as target:
                     for info in source.infolist():
-                        data = source.read(info.filename)
+                        data = self._read_zip_member(source, info.filename)
                         if info.filename == "meta.xml":
                             data = empty_metadata
                             wrote_metadata = True
@@ -242,11 +296,15 @@ class DocumentHandler(BaseHandler):
     def _epub_package_path(self, archive: zipfile.ZipFile) -> str:
         """Return the package document path from an EPUB archive."""
         try:
-            container_xml = archive.read("META-INF/container.xml")
+            container_xml = self._read_zip_member(
+                archive,
+                "META-INF/container.xml",
+                max_bytes=self.MAX_METADATA_XML_BYTES,
+            )
         except KeyError:
-            for name in archive.namelist():
-                if name.lower().endswith(".opf"):
-                    return name
+            for info in archive.infolist():
+                if info.filename.lower().endswith(".opf"):
+                    return info.filename
             raise ValueError("EPUB package document not found")
 
         root = ET.fromstring(container_xml)
@@ -262,8 +320,13 @@ class DocumentHandler(BaseHandler):
         """Extract EPUB package metadata from the OPF document."""
         try:
             with zipfile.ZipFile(file_path, "r") as archive:
+                self._validate_zip_archive(archive, file_path)
                 package_path = self._epub_package_path(archive)
-                package_xml = archive.read(package_path)
+                package_xml = self._read_zip_member(
+                    archive,
+                    package_path,
+                    max_bytes=self.MAX_METADATA_XML_BYTES,
+                )
 
             root = ET.fromstring(package_xml)
             metadata_element = self._find_child_by_local_name(root, "metadata")
@@ -322,15 +385,20 @@ class DocumentHandler(BaseHandler):
         """Neutralize EPUB package metadata while preserving book contents."""
         try:
             with zipfile.ZipFile(file_path, "r") as source:
+                self._validate_zip_archive(source, file_path)
                 package_path = self._epub_package_path(source)
-                package_xml = source.read(package_path)
+                package_xml = self._read_zip_member(
+                    source,
+                    package_path,
+                    max_bytes=self.MAX_METADATA_XML_BYTES,
+                )
                 cleaned_package_xml = self._neutralize_epub_package_metadata(
                     package_xml
                 )
 
                 with zipfile.ZipFile(output_path, "w") as target:
                     for info in source.infolist():
-                        data = source.read(info.filename)
+                        data = self._read_zip_member(source, info.filename)
                         if info.filename == package_path:
                             data = cleaned_package_xml
                         target.writestr(info, data)

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -24,6 +24,7 @@ from m_c.core.metadata_processor import MetadataProcessor
 from m_c.core.file_utils import get_file_checksum, validate_file, get_safe_output_path
 from m_c.core.logger import logger
 from m_c.handlers.base_handler import BaseHandler
+from m_c.handlers.document_handler import DocumentHandler
 from m_c.handlers.video_handler import VideoHandler
 from m_c.web.server import WebApp
 
@@ -620,6 +621,50 @@ class TestMetadataCleaner(unittest.TestCase):
                 b"Metadata Cleaner EPUB body",
                 cleaned_archive.read("OPS/chapter.xhtml"),
             )
+
+    def test_odt_metadata_extraction_rejects_too_many_archive_entries(self):
+        """ODT extraction should reject archives with excessive entry counts."""
+        source_odt = os.path.join(self.test_dir, "too_many_entries.odt")
+        self._write_odt(source_odt)
+
+        with patch.object(DocumentHandler, "MAX_ZIP_ENTRIES", 2):
+            metadata = DocumentHandler()._extract_metadata_odt(source_odt)
+
+        self.assertIsNone(metadata)
+
+    def test_odt_metadata_removal_rejects_large_archive_member(self):
+        """ODT cleaning should reject oversized archive members and clean up."""
+        source_odt = os.path.join(self.test_dir, "large_member.odt")
+        cleaned_odt = os.path.join(self.cleaned_dir, "large_member.odt")
+        self._write_odt(source_odt)
+
+        with patch.object(DocumentHandler, "MAX_ZIP_MEMBER_BYTES", 8):
+            result = DocumentHandler()._remove_metadata_odt(source_odt, cleaned_odt)
+
+        self.assertIsNone(result)
+        self.assertFalse(os.path.exists(cleaned_odt))
+
+    def test_epub_metadata_extraction_rejects_large_package_metadata(self):
+        """EPUB extraction should reject oversized package metadata XML."""
+        source_epub = os.path.join(self.test_dir, "large_package.epub")
+        self._write_epub(source_epub)
+
+        with patch.object(DocumentHandler, "MAX_METADATA_XML_BYTES", 32):
+            metadata = DocumentHandler()._extract_metadata_epub(source_epub)
+
+        self.assertIsNone(metadata)
+
+    def test_epub_metadata_removal_rejects_large_archive_total(self):
+        """EPUB cleaning should reject excessive total uncompressed size."""
+        source_epub = os.path.join(self.test_dir, "large_total.epub")
+        cleaned_epub = os.path.join(self.cleaned_dir, "large_total.epub")
+        self._write_epub(source_epub)
+
+        with patch.object(DocumentHandler, "MAX_ZIP_UNCOMPRESSED_BYTES", 32):
+            result = DocumentHandler()._remove_metadata_epub(source_epub, cleaned_epub)
+
+        self.assertIsNone(result)
+        self.assertFalse(os.path.exists(cleaned_epub))
 
     def test_web_app_metadata_response_shows_original_metadata(self):
         """Web API should expose original metadata for the uploaded file."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.18.8"
+version = "3.18.9"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add ZIP entry-count, per-member, metadata XML, and total uncompressed-size limits for EPUB/ODT handling
- apply archive validation before EPUB/ODT metadata extraction or cleanup reads package members
- add regression coverage for excessive entries, oversized members, oversized package metadata, and excessive archive totals
- document the archive safety posture and prepare v3.18.9 release notes

## Verification
- `poetry run pytest m_c/tests/test_metadata_cleaner.py -k "archive or odt_metadata or epub_metadata"` -> 6 passed
- `poetry check --lock`
- `poetry run pytest` -> 75 passed, 1 skipped
- `poetry run flake8 m_c manage.py`
- `poetry run pip-audit` -> no known vulnerabilities found
- `poetry build`
- verified v3.18.9 wheel metadata and no shipped test module
- `git diff --check`