### PR TITLE
chore: refresh repository health review

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -35,6 +35,25 @@ jobs:
       - name: Check Package Metadata
         run: poetry check --lock
 
+      - name: Verify Release Version
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          tag = os.environ["GITHUB_REF_NAME"]
+          with Path("pyproject.toml").open("rb") as pyproject_file:
+              version = tomllib.load(pyproject_file)["project"]["version"]
+
+          expected_tag = f"v{version}"
+          if tag != expected_tag:
+              raise SystemExit(
+                  f"Release tag {tag} does not match pyproject version "
+                  f"{version}; expected {expected_tag}"
+              )
+          PY
+
       - name: Run Tests
         run: poetry run pytest
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## v3.18.11
+**Release Date**: 2026-05-16
+
+### Maintenance
+- Added a release workflow guard that verifies the pushed tag matches the
+  version in `pyproject.toml` before publishing.
+- Fixed the legacy programmatic batch API so failed files preserve their result
+  slot as `None`.
+- Refreshed the repository health review and roadmap after the v3.18.x
+  maintenance sequence.
+
 ## v3.18.10
 **Release Date**: 2026-05-16
 

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -72,3 +72,19 @@ The release workflow publishes to PyPI and creates the GitHub release using the
 matching `RELEASE_NOTES.md` section as the release body. The Docker publishing
 workflow runs for the same version tags and publishes `ghcr.io/sandy-sp/metadata-cleaner`
 with `vX.Y.Z`, `X.Y.Z`, `X.Y`, and `latest` tags.
+
+Before pushing a release tag, confirm that the tag matches `pyproject.toml`
+exactly. The release workflow enforces this check before publishing.
+
+## Branch Housekeeping
+
+After merged feature and maintenance PRs, prune stale local remote-tracking refs
+with:
+
+```bash
+git fetch --prune
+```
+
+If old remote branches remain visible on GitHub after their PRs are merged or
+closed, delete only branches that are clearly merged, obsolete, and not owned by
+an active Dependabot PR.

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -1,11 +1,18 @@
 # Metadata Cleaner Roadmap
 
-This roadmap tracks possible future work after the v3.2.0 security and
-maintenance release. Items here are intentionally not promises for a specific
-release; they should be validated against user demand, maintenance cost, and
-privacy risk before implementation.
+This roadmap tracks possible future work after the v3.18.x maintenance and
+format-support sequence. Items here are intentionally not promises for a
+specific release; they should be validated against user demand, maintenance
+cost, and privacy risk before implementation.
 
 ## Near Term
+
+### Maintenance Readiness
+- Keep release automation guarded so version tags, package metadata, PyPI
+  releases, GitHub releases, and Docker images cannot drift.
+- Periodically prune stale remote branches after merged roadmap stages.
+- Re-run repository health reviews when dependency alerts, packaging changes,
+  or format-support changes land.
 
 ### Stronger Fixture Coverage
 - Add video integration tests that run when FFmpeg and FFprobe are installed.
@@ -15,9 +22,11 @@ privacy risk before implementation.
   expands.
 
 ### CLI Usability
-- Extend machine-readable file output targets as new JSON surfaces are added.
+- Keep machine-readable file output targets consistent as new JSON surfaces are
+  added.
 - Add additional report filters only if users need more targeted automation
   views.
+- Keep the programmatic API behavior aligned with CLI batch reporting.
 
 ### File Format Support
 - Expand audio/video tests before expanding advertised format support.
@@ -34,7 +43,8 @@ privacy risk before implementation.
 ## Longer Term
 
 ### Desktop Interface
-- Consider a small desktop UI only if CLI usage shows enough demand.
+- Consider a small desktop UI only if CLI and local Web UI usage show enough
+  demand.
 - Keep all processing local by default.
 - Reuse the existing CLI/core processor rather than creating separate cleaning
   logic for the UI.

--- a/docs/PUBLISH.md
+++ b/docs/PUBLISH.md
@@ -41,4 +41,6 @@ git push origin vX.Y.Z
 Before tagging, update `pyproject.toml`, add a matching `RELEASE_NOTES.md`
 section such as `## vX.Y.Z`, run the full verification suite, and make sure
 `PYPI_API_TOKEN` is configured in the repository secrets. The release workflow
-uses that release-notes section as the GitHub Release body.
+verifies that the pushed tag matches the `pyproject.toml` version and uses the
+matching release-notes section as the GitHub Release body. The companion Docker
+workflow publishes the same version tag to GitHub Container Registry.

--- a/docs/REPO_HEALTH_REVIEW.md
+++ b/docs/REPO_HEALTH_REVIEW.md
@@ -3,7 +3,7 @@
 Last reviewed: 2026-05-16
 
 This review captures the current maintenance, security, dependency, and
-documentation state after the v3.18.10 release.
+documentation state after the v3.18.11 maintenance review.
 
 ## Current State
 
@@ -12,6 +12,8 @@ documentation state after the v3.18.10 release.
 - Open GitHub issues: none.
 - Open Dependabot security alerts: none.
 - Open CodeQL/code scanning alerts: none.
+- Recent CI, CodeQL, PyPI release, and Docker release workflows completed
+  successfully for v3.18.10.
 - Branch protection is enabled for `main` with required CI, Docker, package
   smoke, and CodeQL checks.
 - The committed `poetry.lock` file is intentional. It documents the exact
@@ -30,7 +32,7 @@ poetry run pip-audit
 poetry build
 ```
 
-The full test suite result was `76 passed, 1 skipped`.
+The full test suite result was `77 passed, 1 skipped`.
 
 ## Dependency Review
 
@@ -50,6 +52,9 @@ The current dependency freshness check showed these non-security updates:
 PDF cleanup coverage for document info and XMP metadata removal. Patch/minor
 development dependency updates can usually follow normal Dependabot review.
 
+The current dependency freshness check showed only non-runtime or transitive
+patch/minor updates: `coverage`, `idna`, and `requests`.
+
 ## Maintenance Findings
 
 - A stale `tools/doc` gitlink was still tracked without a matching
@@ -61,8 +66,18 @@ development dependency updates can usually follow normal Dependabot review.
   viewing/deletion.
 - Release artifacts exclude `m_c/tests`; CI and package smoke coverage validate
   the package before release without shipping test code to users.
+- The release workflow now verifies that the pushed version tag matches
+  `pyproject.toml` before publishing to PyPI or creating a GitHub release.
+- The legacy `MetadataProcessor.process_batch()` API now preserves one result
+  slot per input file, returning `None` for failed files.
+- Several stale remote feature, maintenance, and Dependabot branch refs are
+  visible locally even though no PRs are open. Prune local remote-tracking refs
+  and delete obsolete GitHub branches only after confirming they are no longer
+  active.
 
 ## Next Recommended Work
 
-Re-run this review when the next dependency/security alert, format support
-change, or packaging update lands.
+1. Clean up stale remote branches left by completed roadmap stages.
+2. Add FFmpeg/FFprobe-gated video integration fixture coverage.
+3. Add another generated audio-container fixture only if it can be created
+   without fragile external tooling.

--- a/m_c/core/metadata_processor.py
+++ b/m_c/core/metadata_processor.py
@@ -107,6 +107,7 @@ class MetadataProcessor:
                     logger.info(f"Successfully processed: {file} -> {result}")
                 else:
                     logger.error(f"Failed to process file: {file}")
+                    results.append(None)
             except Exception as e:
                 logger.error(f"Error processing file {file}: {e}", exc_info=True)
                 results.append(None)

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -366,6 +366,17 @@ class TestMetadataCleaner(unittest.TestCase):
                 self.assertTrue(os.path.exists(output_file))
                 self.assertTrue(os.path.exists(file_path))
 
+    def test_process_batch_preserves_result_slots_for_failures(self):
+        """Legacy batch API should return one result slot for each input file."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("broken.pdf", "wb") as broken_pdf:
+                broken_pdf.write(b"not a valid pdf")
+
+            results = MetadataProcessor().process_batch(["broken.pdf"])
+
+            self.assertEqual(results, [None])
+
     def test_edit_metadata(self):
         """Test metadata editing."""
         output_file = self.processor.edit_metadata(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.18.10"
+version = "3.18.11"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- refresh repository health, roadmap, maintenance, and publishing docs after the v3.18.x maintenance sequence
- add a release workflow guard that verifies the pushed tag matches pyproject.toml before publishing
- fix the legacy MetadataProcessor.process_batch API so failed files preserve a None result slot

## Review snapshot
- open PRs: none before this branch
- open issues: none
- open Dependabot security alerts: none
- open CodeQL/code scanning alerts: none
- dependency freshness: only coverage, idna, and requests patch/minor updates available
- branch protection: enabled with Python 3.11/3.12/3.13, Docker build, Package smoke, and Analyze Python required

## Verification
- poetry check --lock
- poetry run flake8 m_c manage.py
- poetry run pytest m_c/tests/test_metadata_cleaner.py -k "process_batch"
- GITHUB_REF_NAME=v3.18.11 release version guard smoke
- poetry run pytest
- poetry run pip-audit
- poetry build
- git diff --check
- wheel metadata inspection confirmed Version: 3.18.11 and no tests in the wheel