### PR TITLE
test: strengthen video metadata coverage

### DIFF
--- a/.github/scripts/package_smoke.py
+++ b/.github/scripts/package_smoke.py
@@ -101,6 +101,9 @@ def assert_view_payloads():
 
 
 def assert_delete_summary():
+    source_video_payload = read_json_output("view", str(ROOT / "video.mp4"))
+    source_video_stream = source_video_payload["metadata"]["streams"][0]
+
     dry_run = run_cli("delete", str(ROOT), "--dry-run", "--json-summary")
     dry_run_payload = json.loads(dry_run.stdout)
     assert dry_run_payload["status"] == "success", dry_run_payload
@@ -126,10 +129,21 @@ def assert_delete_summary():
     cleaned_video = CLEANED / "video.mp4"
     assert cleaned_video.exists(), report
     cleaned_video_payload = read_json_output("view", str(cleaned_video))
+    cleaned_video_stream = cleaned_video_payload["metadata"]["streams"][0]
     cleaned_title = cleaned_video_payload["metadata"]["format"].get("tags", {}).get(
         "title"
     )
     assert cleaned_title != "Smoke Video", cleaned_video_payload
+    assert source_video_stream["codec_type"] == "video", source_video_payload
+    assert source_video_stream["codec_name"] == cleaned_video_stream["codec_name"], (
+        cleaned_video_payload
+    )
+    assert source_video_stream["width"] == cleaned_video_stream["width"], (
+        cleaned_video_payload
+    )
+    assert source_video_stream["height"] == cleaned_video_stream["height"], (
+        cleaned_video_payload
+    )
 
 
 def main():

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v3.18.12
+**Release Date**: 2026-05-16
+
+### Maintenance
+- Strengthened FFmpeg/FFprobe-gated video integration coverage to confirm
+  source metadata remains intact, cleaned metadata is removed, and video stream
+  properties are preserved after stream-copy cleanup.
+- Updated the roadmap and health review after branch housekeeping and video
+  fixture coverage.
+
 ## v3.18.11
 **Release Date**: 2026-05-16
 

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -10,12 +10,13 @@ cost, and privacy risk before implementation.
 ### Maintenance Readiness
 - Keep release automation guarded so version tags, package metadata, PyPI
   releases, GitHub releases, and Docker images cannot drift.
-- Periodically prune stale remote branches after merged roadmap stages.
+- Periodically prune stale remote-tracking refs after merged roadmap stages.
 - Re-run repository health reviews when dependency alerts, packaging changes,
   or format-support changes land.
 
 ### Stronger Fixture Coverage
-- Add video integration tests that run when FFmpeg and FFprobe are installed.
+- Keep FFmpeg/FFprobe-gated video integration tests current as video behavior
+  changes.
 - Add fixture assertions for additional audio containers beyond WAV/FLAC when
   their metadata can be generated without external system tools.
 - Keep installed-package smoke coverage current as optional system-tool behavior

--- a/docs/REPO_HEALTH_REVIEW.md
+++ b/docs/REPO_HEALTH_REVIEW.md
@@ -3,7 +3,7 @@
 Last reviewed: 2026-05-16
 
 This review captures the current maintenance, security, dependency, and
-documentation state after the v3.18.11 maintenance review.
+documentation state after the v3.18.12 maintenance review.
 
 ## Current State
 
@@ -13,7 +13,7 @@ documentation state after the v3.18.11 maintenance review.
 - Open Dependabot security alerts: none.
 - Open CodeQL/code scanning alerts: none.
 - Recent CI, CodeQL, PyPI release, and Docker release workflows completed
-  successfully for v3.18.10.
+  successfully for v3.18.11.
 - Branch protection is enabled for `main` with required CI, Docker, package
   smoke, and CodeQL checks.
 - The committed `poetry.lock` file is intentional. It documents the exact
@@ -32,7 +32,9 @@ poetry run pip-audit
 poetry build
 ```
 
-The full test suite result was `77 passed, 1 skipped`.
+The full test suite result is `77 passed, 1 skipped` when FFmpeg/FFprobe are
+not installed. The gated video integration test runs when those tools are
+available.
 
 ## Dependency Review
 
@@ -70,14 +72,14 @@ patch/minor updates: `coverage`, `idna`, and `requests`.
   `pyproject.toml` before publishing to PyPI or creating a GitHub release.
 - The legacy `MetadataProcessor.process_batch()` API now preserves one result
   slot per input file, returning `None` for failed files.
-- Several stale remote feature, maintenance, and Dependabot branch refs are
-  visible locally even though no PRs are open. Prune local remote-tracking refs
-  and delete obsolete GitHub branches only after confirming they are no longer
-  active.
+- Stale local remote-tracking refs from completed roadmap stages were pruned;
+  the actual remote now only advertises `main`.
+- FFmpeg/FFprobe-gated video integration coverage verifies metadata removal,
+  original preservation, and stream-property preservation for a generated MP4
+  fixture.
 
 ## Next Recommended Work
 
-1. Clean up stale remote branches left by completed roadmap stages.
-2. Add FFmpeg/FFprobe-gated video integration fixture coverage.
-3. Add another generated audio-container fixture only if it can be created
+1. Add another generated audio-container fixture only if it can be created
    without fragile external tooling.
+2. Re-run dependency/security review when Dependabot opens the next update.

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -1675,7 +1675,7 @@ class TestMetadataCleaner(unittest.TestCase):
         "FFmpeg and FFprobe are required for video integration coverage",
     )
     def test_generated_video_metadata_removal_with_ffmpeg(self):
-        """Video cleanup should strip container metadata without re-encoding."""
+        """Video cleanup should strip metadata while preserving stream shape."""
         source_video = os.path.join(self.test_dir, "generated.mp4")
         cleaned_video = os.path.join(self.cleaned_dir, "generated_cleaned.mp4")
 
@@ -1701,17 +1701,37 @@ class TestMetadataCleaner(unittest.TestCase):
             check=True,
         )
 
-        output_file = VideoHandler().remove_metadata(source_video, cleaned_video)
-        metadata = VideoHandler().extract_metadata(cleaned_video)
+        source_metadata = VideoHandler().extract_metadata(source_video)
+        self.assertEqual(
+            source_metadata.get("format", {}).get("tags", {}).get("title"),
+            "Metadata Cleaner Test",
+        )
+
+        output_file = self.processor.delete_metadata(source_video, cleaned_video)
+        cleaned_metadata = VideoHandler().extract_metadata(cleaned_video)
+        original_metadata_after_cleanup = VideoHandler().extract_metadata(source_video)
+
+        source_stream = source_metadata["streams"][0]
+        cleaned_stream = cleaned_metadata["streams"][0]
 
         self.assertEqual(output_file, cleaned_video)
         self.assertTrue(os.path.exists(source_video))
         self.assertTrue(os.path.exists(cleaned_video))
         self.assertNotEqual(os.path.getsize(cleaned_video), 0)
-        self.assertNotEqual(
-            metadata.get("format", {}).get("tags", {}).get("title"),
+        self.assertEqual(
+            original_metadata_after_cleanup.get("format", {})
+            .get("tags", {})
+            .get("title"),
             "Metadata Cleaner Test",
         )
+        self.assertNotEqual(
+            cleaned_metadata.get("format", {}).get("tags", {}).get("title"),
+            "Metadata Cleaner Test",
+        )
+        self.assertEqual(source_stream.get("codec_type"), "video")
+        self.assertEqual(source_stream.get("codec_name"), cleaned_stream.get("codec_name"))
+        self.assertEqual(source_stream.get("width"), cleaned_stream.get("width"))
+        self.assertEqual(source_stream.get("height"), cleaned_stream.get("height"))
 
     def test_recursive_scanning(self):
         """Test recursive file scanning logic."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.18.11"
+version = "3.18.12"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- strengthen the FFmpeg/FFprobe-gated generated video integration test
- verify original video metadata remains intact, cleaned metadata is removed, and stream properties are preserved
- extend installed-package smoke coverage so CI validates video stream preservation where FFmpeg/FFprobe are installed
- update release notes, roadmap, and repo health review for v3.18.12

## Verification
- poetry check --lock
- poetry run flake8 m_c manage.py .github/scripts/package_smoke.py
- GITHUB_REF_NAME=v3.18.12 release version guard smoke
- poetry run pytest m_c/tests/test_metadata_cleaner.py -k "video"
- poetry run pytest
- poetry run pip-audit
- poetry build
- git diff --check
- wheel metadata inspection confirmed Version: 3.18.12 and no tests in the wheel

## Notes
- local machine does not have FFmpeg/FFprobe, so the generated-video integration test is skipped locally; the package-smoke CI job installs FFmpeg/FFprobe and exercises the stronger video assertions.