### PR TITLE
test: add m4a audio fixture coverage

### DIFF
--- a/.github/scripts/package_smoke.py
+++ b/.github/scripts/package_smoke.py
@@ -65,6 +65,31 @@ def write_fixtures():
             "-f",
             "lavfi",
             "-i",
+            "sine=frequency=440:sample_rate=8000",
+            "-t",
+            "1",
+            "-metadata",
+            "title=Smoke Audio",
+            "-metadata",
+            "artist=Smoke Artist",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "32k",
+            str(ROOT / "audio.m4a"),
+            "-y",
+        ]
+    )
+
+    run_command(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
             "testsrc=size=16x16:rate=1",
             "-t",
             "1",
@@ -94,6 +119,11 @@ def assert_view_payloads():
     wav_payload = read_json_output("view", str(ROOT / "audio.wav"))
     assert wav_payload["status"] in {"success", "no_metadata"}, wav_payload
 
+    m4a_payload = read_json_output("view", str(ROOT / "audio.m4a"))
+    assert m4a_payload["status"] == "success", m4a_payload
+    assert m4a_payload["metadata"].get("title") == ["Smoke Audio"], m4a_payload
+    assert m4a_payload["metadata"].get("artist") == ["Smoke Artist"], m4a_payload
+
     video_payload = read_json_output("view", str(ROOT / "video.mp4"))
     assert video_payload["status"] == "success", video_payload
     video_title = video_payload["metadata"]["format"]["tags"].get("title")
@@ -107,8 +137,8 @@ def assert_delete_summary():
     dry_run = run_cli("delete", str(ROOT), "--dry-run", "--json-summary")
     dry_run_payload = json.loads(dry_run.stdout)
     assert dry_run_payload["status"] == "success", dry_run_payload
-    assert dry_run_payload["total"] == 5, dry_run_payload
-    assert dry_run_payload["would_process"] == 5, dry_run_payload
+    assert dry_run_payload["total"] == 6, dry_run_payload
+    assert dry_run_payload["would_process"] == 6, dry_run_payload
 
     run_cli(
         "delete",
@@ -122,9 +152,14 @@ def assert_delete_summary():
 
     report = json.loads(REPORT.read_text())
     assert report["status"] == "success", report
-    assert report["total"] == 5, report
-    assert report["succeeded"] == 5, report
-    assert len(report["files"]) == 5, report
+    assert report["total"] == 6, report
+    assert report["succeeded"] == 6, report
+    assert len(report["files"]) == 6, report
+
+    cleaned_audio = CLEANED / "audio.m4a"
+    assert cleaned_audio.exists(), report
+    cleaned_audio_payload = read_json_output("view", str(cleaned_audio))
+    assert cleaned_audio_payload["status"] == "no_metadata", cleaned_audio_payload
 
     cleaned_video = CLEANED / "video.mp4"
     assert cleaned_video.exists(), report

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v3.18.13
+**Release Date**: 2026-05-16
+
+### Maintenance
+- Added FFmpeg-gated generated M4A audio integration coverage to verify
+  compressed audio tag cleanup, original preservation, and stream property
+  preservation.
+- Extended installed-package smoke coverage to exercise M4A metadata viewing
+  and cleanup in CI where FFmpeg is installed.
+
 ## v3.18.12
 **Release Date**: 2026-05-16
 

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -17,8 +17,10 @@ cost, and privacy risk before implementation.
 ### Stronger Fixture Coverage
 - Keep FFmpeg/FFprobe-gated video integration tests current as video behavior
   changes.
-- Add fixture assertions for additional audio containers beyond WAV/FLAC when
-  their metadata can be generated without external system tools.
+- Keep FFmpeg-gated compressed audio fixture coverage current where external
+  tooling is already present in CI.
+- Add more pure-Python audio fixtures beyond WAV/FLAC only when their metadata
+  can be generated without fragile external tooling.
 - Keep installed-package smoke coverage current as optional system-tool behavior
   expands.
 

--- a/docs/REPO_HEALTH_REVIEW.md
+++ b/docs/REPO_HEALTH_REVIEW.md
@@ -3,7 +3,7 @@
 Last reviewed: 2026-05-16
 
 This review captures the current maintenance, security, dependency, and
-documentation state after the v3.18.12 maintenance review.
+documentation state after the v3.18.13 maintenance review.
 
 ## Current State
 
@@ -13,7 +13,7 @@ documentation state after the v3.18.12 maintenance review.
 - Open Dependabot security alerts: none.
 - Open CodeQL/code scanning alerts: none.
 - Recent CI, CodeQL, PyPI release, and Docker release workflows completed
-  successfully for v3.18.11.
+  successfully for v3.18.12.
 - Branch protection is enabled for `main` with required CI, Docker, package
   smoke, and CodeQL checks.
 - The committed `poetry.lock` file is intentional. It documents the exact
@@ -32,9 +32,9 @@ poetry run pip-audit
 poetry build
 ```
 
-The full test suite result is `77 passed, 1 skipped` when FFmpeg/FFprobe are
-not installed. The gated video integration test runs when those tools are
-available.
+The full test suite result is `77 passed, 2 skipped` when FFmpeg/FFprobe are
+not installed. The gated M4A audio and MP4 video integration tests run when
+those tools are available.
 
 ## Dependency Review
 
@@ -77,9 +77,12 @@ patch/minor updates: `coverage`, `idna`, and `requests`.
 - FFmpeg/FFprobe-gated video integration coverage verifies metadata removal,
   original preservation, and stream-property preservation for a generated MP4
   fixture.
+- FFmpeg-gated compressed audio integration coverage verifies M4A metadata
+  removal, original preservation, and stream-property preservation for a
+  generated fixture.
 
 ## Next Recommended Work
 
-1. Add another generated audio-container fixture only if it can be created
-   without fragile external tooling.
-2. Re-run dependency/security review when Dependabot opens the next update.
+1. Re-run dependency/security review when Dependabot opens the next update.
+2. Consider standalone executable packaging only after another release cycle of
+   CLI and package-smoke stability.

--- a/m_c/tests/test_metadata_cleaner.py
+++ b/m_c/tests/test_metadata_cleaner.py
@@ -1671,6 +1671,64 @@ class TestMetadataCleaner(unittest.TestCase):
         )
 
     @unittest.skipUnless(
+        shutil.which("ffmpeg"),
+        "FFmpeg is required for generated M4A audio integration coverage",
+    )
+    def test_generated_m4a_metadata_removal_preserves_original(self):
+        """Audio cleanup should strip M4A tags from a copied compressed file."""
+        source_m4a = os.path.join(self.test_dir, "generated.m4a")
+        cleaned_m4a = os.path.join(self.cleaned_dir, "generated_cleaned.m4a")
+
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=440:sample_rate=8000",
+                "-t",
+                "1",
+                "-metadata",
+                "title=Fixture Title",
+                "-metadata",
+                "artist=Fixture Artist",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "32k",
+                source_m4a,
+                "-y",
+            ],
+            check=True,
+        )
+
+        source_metadata = self.processor.view_metadata(source_m4a)
+        self.assertEqual(source_metadata["title"], ["Fixture Title"])
+        self.assertEqual(source_metadata["artist"], ["Fixture Artist"])
+
+        output_file = self.processor.delete_metadata(source_m4a, cleaned_m4a)
+
+        self.assertEqual(output_file, cleaned_m4a)
+        self.assertTrue(os.path.exists(source_m4a))
+        self.assertTrue(os.path.exists(cleaned_m4a))
+        self.assertEqual(
+            self.processor.view_metadata(source_m4a)["title"],
+            ["Fixture Title"],
+        )
+        self.assertEqual(dict(MutagenFile(cleaned_m4a, easy=True)), {})
+        self.assertEqual(
+            MutagenFile(source_m4a).info.sample_rate,
+            MutagenFile(cleaned_m4a).info.sample_rate,
+        )
+        self.assertEqual(
+            MutagenFile(source_m4a).info.channels,
+            MutagenFile(cleaned_m4a).info.channels,
+        )
+
+    @unittest.skipUnless(
         shutil.which("ffmpeg") and shutil.which("ffprobe"),
         "FFmpeg and FFprobe are required for video integration coverage",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.18.12"
+version = "3.18.13"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },


### PR DESCRIPTION
## Summary
- add FFmpeg-gated generated M4A audio integration coverage
- verify M4A tag cleanup preserves the original file and basic stream properties
- extend installed-package smoke coverage to create, view, clean, and verify M4A files where FFmpeg is installed
- update release notes, roadmap, and repo health review for v3.18.13

## Verification
- poetry check --lock
- poetry run flake8 m_c manage.py .github/scripts/package_smoke.py
- GITHUB_REF_NAME=v3.18.13 release version guard smoke
- poetry run pytest m_c/tests/test_metadata_cleaner.py -k "audio or m4a or wav or flac"
- poetry run pytest
- poetry run pip-audit
- poetry build
- git diff --check
- wheel metadata inspection confirmed Version: 3.18.13 and no tests in the wheel

## Notes
- local machine does not have FFmpeg, so the generated M4A integration test skips locally; the package-smoke CI job installs FFmpeg and exercises the M4A fixture path.