### PR TITLE
docs: refresh public project documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+Thanks for helping improve Metadata Cleaner. The project is intentionally small
+and privacy-focused, so changes should stay conservative and easy to audit.
+
+## Development Setup
+
+```bash
+git clone https://github.com/sandy-sp/metadata-cleaner.git
+cd metadata-cleaner
+poetry install --with dev
+poetry run metadata-cleaner --help
+```
+
+Optional system tools improve local coverage:
+
+- ExifTool for AVIF, HEIC, HEIF, and broader image metadata paths
+- FFmpeg and FFprobe for video and generated compressed-audio fixtures
+
+## Verification
+
+Run these before opening a pull request:
+
+```bash
+poetry check --lock
+poetry run pytest
+poetry run flake8 m_c manage.py .github/scripts/package_smoke.py
+poetry run pip-audit
+poetry build
+```
+
+If FFmpeg or FFprobe are not installed, the generated M4A and MP4 integration
+tests skip locally. CI package-smoke coverage installs those tools and exercises
+the built wheel.
+
+## Pull Request Guidelines
+
+- Keep changes scoped to one behavior or maintenance theme.
+- Prefer cleaned-copy behavior over in-place mutation.
+- Add focused tests for metadata removal, unsupported inputs, and machine-
+  readable output changes.
+- Update `README.md`, `docs/USAGE.md`, `docs/API_REFERENCE.md`, and
+  `RELEASE_NOTES.md` when user-visible behavior changes.
+- Do not commit private sample files, large binary fixtures, logs, caches, or
+  local Web UI workspaces.
+
+## Release Notes
+
+Each release needs a matching `RELEASE_NOTES.md` section named `## vX.Y.Z`.
+The release workflow verifies that the pushed tag matches `pyproject.toml` and
+uses that section as the GitHub Release body.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,22 @@
 [![PyPI version](https://badge.fury.io/py/metadata-cleaner.svg)](https://pypi.org/project/metadata-cleaner/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Metadata Cleaner is a privacy-focused CLI for viewing and removing metadata from
-local files. It writes cleaned copies by default and avoids modifying originals
-in-place.
+Metadata Cleaner is a privacy-focused local tool for viewing and removing
+metadata from images, documents, audio, and video files. It writes cleaned
+copies by default, keeps originals unchanged, and includes CLI, JSON automation,
+Docker, and a local Web UI for side-by-side metadata checks.
+
+## Highlights
+
+- View metadata before cleaning.
+- Remove metadata into separate cleaned copies.
+- Compare original and cleaned metadata in a local-only Web UI.
+- Process individual files or recursive folders.
+- Generate machine-readable JSON reports for automation.
+- Add SHA-256, SHA-512, or BLAKE2b checksums to reports.
+- Preserve source timestamps on cleaned outputs when needed.
+- Publish-ready CI coverage for Python, package smoke tests, Docker builds,
+  CodeQL, and dependency audits.
 
 ## Supported Files
 
@@ -16,16 +29,26 @@ in-place.
 - Audio: MP3, WAV, FLAC, OGG, AAC, M4A, WMA
 - Video: MP4, MKV, MOV, AVI, WEBM, FLV
 
-Video support requires `ffmpeg` and `ffprobe`. AVIF and broader metadata
-coverage benefit from `exiftool`.
+Some formats need system tools for best coverage:
 
-## Installation
+- `ffmpeg` and `ffprobe` are required for video metadata handling.
+- `exiftool` is required for AVIF, HEIC, and HEIF cleanup and improves image
+  metadata coverage.
+- The published Docker image includes these optional tools.
+
+## Install
 
 Requires Python 3.11 or newer.
 
 ```bash
 pip install metadata-cleaner
 metadata-cleaner --help
+```
+
+Use Docker when you want the optional system tools preinstalled:
+
+```bash
+docker run --rm -v "$(pwd):/data" ghcr.io/sandy-sp/metadata-cleaner:latest delete /data/photos
 ```
 
 For development:
@@ -37,7 +60,7 @@ poetry install --with dev
 poetry run metadata-cleaner --help
 ```
 
-## CLI Usage
+## Quick Start
 
 View metadata:
 
@@ -45,7 +68,54 @@ View metadata:
 metadata-cleaner view sample.jpg
 ```
 
-Print metadata for automation:
+Clean one file:
+
+```bash
+metadata-cleaner delete sample.jpg
+```
+
+By default, the cleaned copy is written under a `cleaned/` directory next to the
+source file. To choose the output path:
+
+```bash
+metadata-cleaner delete sample.jpg --output cleaned/sample.jpg
+```
+
+Preview a folder run without writing files:
+
+```bash
+metadata-cleaner delete ./photos --dry-run
+```
+
+Clean a folder recursively:
+
+```bash
+metadata-cleaner delete ./photos --output ./cleaned-photos
+```
+
+## Local Web UI
+
+Start a single-page local Web UI:
+
+```bash
+metadata-cleaner web
+```
+
+The Web UI binds to `127.0.0.1` by default, shows original metadata beside
+cleaned-copy metadata, and lets you download cleaned files. The `Files` button
+lists uploaded originals and cleaned copies from the current local session with
+view and delete actions.
+
+Temporary Web UI files are stored in a temporary directory unless you provide a
+workspace:
+
+```bash
+metadata-cleaner web --workspace ./metadata-cleaner-workspace
+```
+
+## Automation
+
+Print metadata as JSON:
 
 ```bash
 metadata-cleaner view sample.jpg --json
@@ -57,31 +127,7 @@ Write metadata JSON to a file:
 metadata-cleaner view sample.jpg --json-output reports/metadata.json
 ```
 
-Remove metadata from one file:
-
-```bash
-metadata-cleaner delete sample.jpg
-```
-
-Write to a specific file:
-
-```bash
-metadata-cleaner delete sample.jpg --output cleaned/sample.jpg
-```
-
-Process a folder recursively:
-
-```bash
-metadata-cleaner delete ./photos --output ./cleaned-photos
-```
-
-Preview a run without writing files:
-
-```bash
-metadata-cleaner delete ./photos --dry-run
-```
-
-Write a JSON summary report:
+Write a delete summary report:
 
 ```bash
 metadata-cleaner delete ./photos --summary-file reports/summary.json
@@ -90,32 +136,53 @@ metadata-cleaner delete ./photos --summary-file reports/summary.json
 The shared `--json-output reports/summary.json` option writes the same delete
 summary payload.
 
-Summary reports include per-file status and output paths for audit trails.
-Add `--checksums` to include input/output hashes. SHA-256 is the default; use
-`--checksum-algorithm sha512` or `--checksum-algorithm blake2b` for stronger
-hash reports.
-Add `--preserve-timestamps` when cleaned files should keep source file times.
-Use `--report-detail compact` or `--report-detail summary` for smaller reports.
-Use `--report-filter failed` to list only failed per-file entries.
-Formats that copy, rewrite, re-save, use ExifTool, delete audio tags, or remux
-video include precise per-file processing notes in JSON summary reports.
+Add checksums:
 
-Edit metadata where supported:
+```bash
+metadata-cleaner delete ./photos --summary-file reports/summary.json --checksums
+metadata-cleaner delete ./photos --json-summary --checksums --checksum-algorithm sha512
+```
+
+Use compact reports for large jobs:
+
+```bash
+metadata-cleaner delete ./photos --json-summary --report-detail compact
+metadata-cleaner delete ./photos --json-summary --report-filter failed
+```
+
+Summary reports include per-file status, output paths, optional checksums,
+failure reasons, and format-specific processing notes that explain whether a
+handler copies, rewrites, re-saves, uses ExifTool, deletes audio tags, or remuxes
+video with FFmpeg stream copy.
+
+## Safety Model
+
+- Originals are not modified by metadata removal.
+- Handlers reject in-place cleanup where input and output paths are the same.
+- EPUB and ODT ZIP packages are checked against archive safety limits before
+  metadata XML is read or rewritten.
+- ExifTool, FFmpeg, and FFprobe subprocess calls use bounded timeouts.
+- Logs go to stderr by default; file logging is opt-in.
+- The Web UI is local-only by default and scopes file viewing/deletion to its
+  managed workspace.
+
+This tool removes common metadata fields using format-specific libraries and
+system tools. It is not a guarantee that every possible identifying byte,
+watermark, hidden payload, or content-derived signal has been removed. For
+high-risk publishing workflows, inspect outputs with independent tools before
+release.
+
+## Edit Metadata
+
+Editing is available only where handlers support it, currently most useful for
+audio files through Mutagen:
 
 ```bash
 metadata-cleaner edit song.mp3 --changes '{"artist": "Unknown"}'
 ```
 
-Start the local Web UI:
-
-```bash
-metadata-cleaner web
-```
-
-The Web UI runs on `127.0.0.1` by default and shows original metadata next to
-cleaned-copy metadata so you can verify what changed before using the cleaned
-file. Use the `Files` button to view or delete uploaded originals and cleaned
-copies saved in the current local session.
+Use metadata removal when you need a cleaned copy. Editing may modify the target
+file in place.
 
 ## Development Checks
 
@@ -125,38 +192,16 @@ python3 manage.py lint
 python3 manage.py check
 ```
 
-CI runs tests, lint, and `pip-audit` on pull requests and pushes to `main`.
-
-## Docker
-
-```bash
-docker build -t metadata-cleaner .
-docker run --rm -v "$(pwd)/photos:/data" metadata-cleaner delete /data
-```
-
-Published release images are available from GitHub Container Registry:
-
-```bash
-docker run --rm -v "$(pwd)/photos:/data" ghcr.io/sandy-sp/metadata-cleaner:latest delete /data
-```
-
-## Logging
-
-By default, logs go to stderr only. To write a log file, opt in explicitly:
-
-```bash
-METADATA_CLEANER_LOG_FILE=./metadata-cleaner.log metadata-cleaner delete sample.jpg
-```
-
-Use debug logging when needed:
-
-```bash
-METADATA_CLEANER_LOG_LEVEL=DEBUG metadata-cleaner view sample.jpg
-```
+CI runs tests, lint, `pip-audit`, package smoke coverage, Docker builds, and
+CodeQL on protected branches and pull requests.
 
 ## Resources
 
-- [API Reference](docs/API_REFERENCE.md)
-- [Usage Guide](docs/USAGE.md)
-- [Architecture](docs/ARCHITECTURE.md)
-- [Repository Health Review](docs/REPO_HEALTH_REVIEW.md)
+- [Usage Guide](https://github.com/sandy-sp/metadata-cleaner/blob/main/docs/USAGE.md)
+- [API Reference](https://github.com/sandy-sp/metadata-cleaner/blob/main/docs/API_REFERENCE.md)
+- [Architecture](https://github.com/sandy-sp/metadata-cleaner/blob/main/docs/ARCHITECTURE.md)
+- [Maintenance And Security](https://github.com/sandy-sp/metadata-cleaner/blob/main/docs/MAINTENANCE.md)
+- [Roadmap](https://github.com/sandy-sp/metadata-cleaner/blob/main/docs/PLANNED_FEATURES.md)
+- [Release Notes](https://github.com/sandy-sp/metadata-cleaner/blob/main/RELEASE_NOTES.md)
+- [Security Policy](https://github.com/sandy-sp/metadata-cleaner/blob/main/SECURITY.md)
+- [Contributing](https://github.com/sandy-sp/metadata-cleaner/blob/main/CONTRIBUTING.md)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## v3.18.14
+**Release Date**: 2026-05-16
+
+### Documentation
+- Refreshed the README as the public entry point with current CLI, Web UI,
+  automation, Docker, safety, optional-tool, and roadmap guidance.
+- Added public `SECURITY.md` and `CONTRIBUTING.md` files.
+- Added project metadata links for documentation, changelog, and security
+  policy, and included public docs in source distributions.
+- Updated usage, API, architecture, maintenance, roadmap, and health-review
+  docs after the v3.18.x feature and maintenance sequence.
+
 ## v3.18.13
 **Release Date**: 2026-05-16
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+Metadata Cleaner handles local user files, so security and privacy issues are
+taken seriously.
+
+## Supported Versions
+
+Security fixes are targeted at the latest released version on PyPI and the
+current `main` branch.
+
+## Reporting A Vulnerability
+
+Please do not open a public issue for a vulnerability if it includes exploit
+details or sensitive sample files.
+
+Report security issues privately through GitHub's private vulnerability
+reporting when available, or contact the maintainer through the email listed in
+`pyproject.toml`.
+
+Helpful reports include:
+
+- affected version or commit
+- operating system and Python version
+- file type and tool path involved
+- whether optional tools such as ExifTool, FFmpeg, or FFprobe were installed
+- minimal reproduction steps that do not include private user files
+
+## Scope
+
+In scope:
+
+- crashes, hangs, or resource exhaustion caused by malformed files
+- path traversal or unintended file deletion in CLI or Web UI flows
+- dependency vulnerabilities in the released package or Docker image
+- incorrect behavior that modifies originals during metadata removal
+
+Out of scope:
+
+- claims that a file may still contain non-standard metadata not supported by
+  the relevant parser
+- issues requiring public exposure of the local-only Web UI against documented
+  defaults
+- vulnerabilities in external tools such as ExifTool or FFmpeg unless this
+  project invokes them unsafely
+
+## Privacy Expectations
+
+Metadata removal keeps originals unchanged and writes cleaned copies. This tool
+does not guarantee removal of every possible hidden payload, watermark, or
+content-derived signal. For high-risk publishing workflows, verify cleaned files
+with independent tools before release.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -45,6 +45,19 @@ updated_file = MetadataProcessor().edit_metadata(
 print(updated_file)
 ```
 
+## `process_batch(files: list[str]) -> list[str | None]`
+
+Process a list of files sequentially with the legacy programmatic batch API.
+Each input file has one result slot. Successful files return their cleaned path;
+failed files return `None`.
+
+```python
+from m_c.core.metadata_processor import MetadataProcessor
+
+results = MetadataProcessor().process_batch(["photo.jpg", "document.pdf"])
+print(results)
+```
+
 ## CLI Exit Codes
 
 The CLI returns stable exit codes for automation:
@@ -98,6 +111,9 @@ creates a cleaned copy, and then displays cleaned-copy metadata for comparison.
 The original file is never modified. The local file browser lists uploaded
 originals and cleaned copies from the current Web UI workspace, and supports
 viewing or deleting those managed files.
+
+When no `--workspace` is supplied, uploaded originals and cleaned copies live in
+a temporary directory that is removed when the Web UI server exits.
 
 EPUB and ODT inputs are ZIP-based packages. Metadata extraction and cleanup
 apply archive safety limits before reading package members so excessive entry

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,6 +9,8 @@ Metadata Cleaner is a small Python CLI organized around file-type handlers.
   and batch output path mapping.
 - `manage.py` provides local development shortcuts for install, test, lint,
   audit, and cleanup tasks.
+- `metadata-cleaner web` runs a local-only single-page Web UI that reuses the
+  same core processor and writes cleaned copies into a managed workspace.
 
 ## Core Flow
 
@@ -37,13 +39,22 @@ Metadata Cleaner is a small Python CLI organized around file-type handlers.
 - File logging is opt-in through `METADATA_CLEANER_LOG_FILE`; by default logs go
   to stderr only.
 - Cleaned outputs are written separately from originals.
+- The Web UI binds to localhost by default, rejects public bind hosts, and
+  scopes managed file viewing/deletion to upload and cleaned-copy directories.
 - Dependency scanning is performed with `pip-audit` in CI.
 - Static analysis is performed with CodeQL.
-- Docker image builds are checked in CI so Dockerfile updates are tested before
-  release.
+- Docker image builds and installed-package smoke tests are checked in CI so
+  Dockerfile and packaging updates are tested before release.
 - External ExifTool, FFprobe, and FFmpeg subprocess calls use timeouts so
   malformed files cannot make those tool invocations wait indefinitely.
 - EPUB and ODT ZIP package handling enforces archive safety limits to reduce
   zip-bomb style denial-of-service risk.
 - The project ignores local logs, local agent state, virtual environments, build
   artifacts, and caches.
+
+## Release Coverage
+
+The package smoke workflow installs the built wheel in a clean virtual
+environment and exercises JPEG, PDF, DOCX, WAV, M4A, and MP4 paths with FFmpeg,
+FFprobe, and ExifTool available. Release tags publish to PyPI and GitHub
+Container Registry after tests, lint, package checks, and dependency audit pass.

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -19,6 +19,11 @@ The CI workflow mirrors these checks, builds the Docker image, and smoke-tests
 the built wheel in a clean virtual environment. Tagged releases also publish a
 Docker image to GitHub Container Registry.
 
+Public-facing docs should be reviewed before feature releases. At minimum,
+confirm that `README.md`, `docs/USAGE.md`, `docs/API_REFERENCE.md`,
+`docs/ARCHITECTURE.md`, and `RELEASE_NOTES.md` describe the current command
+surface and safety model.
+
 Record broader review checkpoints in
 [`docs/REPO_HEALTH_REVIEW.md`](REPO_HEALTH_REVIEW.md) when dependency posture,
 branch protection, packaging, or roadmap priorities are re-evaluated.

--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -13,6 +13,8 @@ cost, and privacy risk before implementation.
 - Periodically prune stale remote-tracking refs after merged roadmap stages.
 - Re-run repository health reviews when dependency alerts, packaging changes,
   or format-support changes land.
+- Keep public-facing docs aligned with the current CLI, Web UI, Docker image,
+  and privacy/safety model before each public release.
 
 ### Stronger Fixture Coverage
 - Keep FFmpeg/FFprobe-gated video integration tests current as video behavior
@@ -42,6 +44,8 @@ cost, and privacy risk before implementation.
 
 ### Packaging
 - Consider standalone executables only after the CLI test suite is broader.
+- Prototype standalone executables in a separate branch before adding them to
+  the release workflow.
 
 ## Longer Term
 

--- a/docs/REPO_HEALTH_REVIEW.md
+++ b/docs/REPO_HEALTH_REVIEW.md
@@ -3,7 +3,7 @@
 Last reviewed: 2026-05-16
 
 This review captures the current maintenance, security, dependency, and
-documentation state after the v3.18.13 maintenance review.
+documentation state after the v3.18.14 public-readiness review.
 
 ## Current State
 
@@ -13,12 +13,17 @@ documentation state after the v3.18.13 maintenance review.
 - Open Dependabot security alerts: none.
 - Open CodeQL/code scanning alerts: none.
 - Recent CI, CodeQL, PyPI release, and Docker release workflows completed
-  successfully for v3.18.12.
+  successfully for v3.18.13.
 - Branch protection is enabled for `main` with required CI, Docker, package
   smoke, and CodeQL checks.
 - The committed `poetry.lock` file is intentional. It documents the exact
   dependency set used by CI and releases and gives security scanners a stable
   target.
+- Public-facing README, usage, API, architecture, maintenance, contributing,
+  and security-policy docs describe the current CLI, Web UI, Docker image,
+  automation outputs, optional tools, and privacy/safety model.
+- Package metadata now links to documentation, changelog, and security policy;
+  source distributions include public docs for offline review.
 
 ## Verification Snapshot
 
@@ -34,28 +39,26 @@ poetry build
 
 The full test suite result is `77 passed, 2 skipped` when FFmpeg/FFprobe are
 not installed. The gated M4A audio and MP4 video integration tests run when
-those tools are available.
+those tools are available. Package smoke coverage runs those tool-backed paths
+in CI.
 
 ## Dependency Review
 
 Runtime dependencies should stay narrow because this tool opens user-supplied
-files. During this review, two unused runtime dependencies were identified and
-removed from `pyproject.toml`:
+files. Previous v3.18.x maintenance removed unused runtime dependencies:
 
 - `ffmpeg-python`: video handling calls the `ffmpeg` and `ffprobe` executables
   directly through `subprocess`.
 - `pymupdf`: no current handler imports or uses PyMuPDF.
 
-The current dependency freshness check showed these non-security updates:
+The latest dependency freshness check showed only non-security patch/minor
+updates:
 
 - `coverage`, `idna`, and `requests` have newer patch/minor releases available.
 
 `pikepdf` v10 compatibility was evaluated and adopted in v3.18.10 with focused
 PDF cleanup coverage for document info and XMP metadata removal. Patch/minor
 development dependency updates can usually follow normal Dependabot review.
-
-The current dependency freshness check showed only non-runtime or transitive
-patch/minor updates: `coverage`, `idna`, and `requests`.
 
 ## Maintenance Findings
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -6,6 +6,9 @@
 pip install metadata-cleaner
 ```
 
+Requires Python 3.11 or newer. Video support needs `ffmpeg` and `ffprobe`;
+AVIF, HEIC, and HEIF cleanup needs `exiftool`.
+
 For local development:
 
 ```bash
@@ -129,6 +132,9 @@ metadata-cleaner web
 The Web UI creates cleaned copies and displays original metadata beside cleaned
 metadata for local verification. Use the `Files` button to view or delete
 uploaded originals and cleaned copies saved in the current local session.
+By default the Web UI uses a temporary workspace that is removed when the server
+stops. Use `--workspace ./metadata-cleaner-workspace` to keep uploaded originals
+and cleaned copies between local sessions.
 
 JSON summaries include top-level counts and per-file details:
 
@@ -191,8 +197,24 @@ metadata-cleaner edit song.mp3 --changes '{"artist": "Unknown"}'
 Some formats require system tools:
 
 - AVIF cleanup uses ExifTool.
+- HEIC and HEIF cleanup use ExifTool.
 - Video metadata reads use FFprobe.
 - Video metadata removal uses FFmpeg.
+
+## Docker
+
+Published release images include FFmpeg, FFprobe, and ExifTool:
+
+```bash
+docker run --rm -v "$(pwd):/data" ghcr.io/sandy-sp/metadata-cleaner:latest delete /data/photos
+```
+
+## Privacy Notes
+
+Metadata removal writes cleaned copies and keeps originals unchanged. Some
+formats are rewritten, re-saved, or remuxed during cleanup; JSON reports include
+per-file processing notes for these cases. For high-risk publishing workflows,
+inspect cleaned files with independent tools before release.
 
 ## Logging
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "metadata-cleaner"
-version = "3.18.13"
+version = "3.18.14"
 description = "A CLI tool to remove, edit, or selectively filter metadata from images, documents, audio, and video files."
 authors = [
     { name = "Sandeep Paidipati", email = "sandeep.paidipati@gmail.com" },
@@ -24,6 +24,9 @@ dependencies = [
 Homepage = "https://github.com/sandy-sp/metadata-cleaner"
 Repository = "https://github.com/sandy-sp/metadata-cleaner"
 Issues = "https://github.com/sandy-sp/metadata-cleaner/issues"
+Documentation = "https://github.com/sandy-sp/metadata-cleaner/blob/main/docs/USAGE.md"
+Changelog = "https://github.com/sandy-sp/metadata-cleaner/blob/main/RELEASE_NOTES.md"
+Security = "https://github.com/sandy-sp/metadata-cleaner/blob/main/SECURITY.md"
 
 [project.scripts]
 metadata-cleaner = "m_c.cli.main:cli"
@@ -31,6 +34,12 @@ metadata-cleaner = "m_c.cli.main:cli"
 [tool.poetry]
 packages = [{ include = "m_c" }]
 exclude = ["m_c/tests", "m_c/tests/**"]
+include = [
+    { path = "CONTRIBUTING.md", format = "sdist" },
+    { path = "SECURITY.md", format = "sdist" },
+    { path = "RELEASE_NOTES.md", format = "sdist" },
+    { path = "docs/*.md", format = "sdist" },
+]
 
 # Removed unnecessary dependencies: tinytag, hachoir, av, dmeta, py7zr
 


### PR DESCRIPTION
## Summary
- refresh README as the public entry point for CLI, Web UI, Docker, automation, optional tools, and safety model
- add SECURITY.md and CONTRIBUTING.md
- update usage, API, architecture, maintenance, roadmap, and health-review docs after the v3.18.x feature sequence
- add package metadata links for documentation/changelog/security and include public docs in source distributions

## Recent feature review
- Web UI: local-only, side-by-side original/cleaned metadata, workspace file browser
- CLI automation: JSON output files, summary reports, report filters/details, checksums, timestamp preservation
- Format support: ODT, EPUB, HEIC/HEIF, pikepdf v10, archive limits, ExifTool timeouts
- Release readiness: Docker publishing, package smoke with FFmpeg/ExifTool, release tag/version guard
- Fixture coverage: FLAC, M4A, MP4, PDF info/XMP, archive safety paths

## Verification
- poetry check --lock
- poetry run flake8 m_c manage.py .github/scripts/package_smoke.py
- GITHUB_REF_NAME=v3.18.14 release version guard smoke
- poetry run pytest
- poetry run pip-audit
- poetry build
- git diff --check
- wheel metadata inspection confirmed Version: 3.18.14, project URLs, runtime deps, and no tests in the wheel
- sdist inspection confirmed README, RELEASE_NOTES.md, SECURITY.md, CONTRIBUTING.md, and docs/*.md are included